### PR TITLE
Roadmap: per-feature A/B/C evaluation; drop GPU/parallel/superseded branches

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,144 +1,96 @@
 # lsquant — consolidation roadmap
 
-Trunk `main` now tracks the most advanced line
-(SantiagoGimenezDC/lsquant-official @ main).
-Branches deleted during consolidation are preserved as git tags
-`archive/<name>` and can be restored with `git checkout archive/<name>`.
+Trunk `main` tracks the most advanced line
+(SantiagoGimenezDC/lsquant-official @ main). Every branch that ever existed is
+preserved as a git tag `archive/<name>` and can be restored with
+`git checkout archive/<name>` — nothing was lost in consolidation.
 
-## Highlighted directions
-- **GPU / CUDA KPM backend** — branch `kpm_cuda` (PhD-era GPU implementation).
-- **Parallelism / domain decomposition** — branch `TB-QuantumTransp`.
-- **Python interface & tooling** — branch `python_supported`.
-- **New observables (to be verified)** — branch `New_functions`:
-  optical conductivity, local densities, mean-square displacement, quantum metric.
+## Status of the feature evaluation
 
-## Branches kept for review against `main` and reference
+Each unique commit on every kept branch was classified against `main`:
 
-### `master` — e8ff89e (2024-05-01), 4 commit(s) not in `main`
+- **A — Superseded:** `main` already implements equivalent or better code.
+- **B — Out of scope:** optimisation/infrastructure (memory, GPU, parallelism,
+  build/toolchain) — the owner will handle these later.
+- **C — Functionality `main` lacks:** evaluated for merge.
 
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
+**Outcome:** `main` already contains essentially all of the KPM physics carried
+by the old branches — optical/AC conductivity, local DOS / local densities,
+mean-square displacement, torque, disorder, current operators, spin-projection
+and projected time-evolution operators, and the non-orthogonal solver (further
+developed than any branch). No feature met the bar to merge, so nothing was
+merged into `main`; the genuinely-open items below are kept for review.
 
-<details><summary>unique commits</summary>
+> **Verification note.** This evaluation could not build/run the library in its
+> environment (no Intel MKL and no GSL available; could not be installed). Per
+> the operating rule *"never merge code you cannot verify; doubt → roadmap"*,
+> any feature that would require a build-and-smoke-test to confirm is listed
+> here rather than merged. Re-run the merge evaluation in an environment with
+> the GCC+Eigen+FFTW+GSL toolchain (`toolchain-gcc.cmake`) to close them.
 
-- \`928d17d\` 2024-04-30 — Refined nonOrth
-- \`0bbf919\` 2024-04-30 — Refined nonOrth
-- \`2e3e478\` 2024-05-01 — Ignoring build files
-- \`e8ff89e\` 2024-05-01 — Ignoring build files
+## Dropped during this pass (recoverable via `archive/<name>`)
 
-</details>
+- `kpm_cuda` (GPU/CUDA) and `TB-QuantumTransp` (domain decomposition) — branches
+  **deleted**; out of scope (optimisation). Tags `archive/kpm_cuda`,
+  `archive/TB-QuantumTransp` retain the code if GPU/parallel work resumes.
+- `master` — branch **deleted**; its only source work (2× "Refined nonOrth",
+  2024-04) is **superseded** — `main` has the non-orthogonal solver in many more
+  commits (`Non-orthogonal solver tested`, `ICHOL preconditioning`,
+  `noOrth precision test`, `Flexible bandwidth shift`, …). Other commits were
+  `.gitignore` only. Tag `archive/master`.
+- `stable` — branch **deleted**; 2019 legacy snapshot, fully superseded. Tag
+  `archive/stable`.
+- `new_currents` — branch **deleted**; a strict subset of `alpha_release`
+  (0 unique commits). Tag `archive/new_currents`.
 
-### `New_functions` — 7fa8ba5 (2025-02-20), 6 commit(s) not in `main`
+## Branches kept — open items to review against `main` and reference
 
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
+### `New_functions` — `7fa8ba5` (2025-02-20)
 
-<details><summary>unique commits</summary>
+The 2025 observables work, marked "to be checked" by its author.
 
-- \`928d17d\` 2024-04-30 — Refined nonOrth
-- \`0bbf919\` 2024-04-30 — Refined nonOrth
-- \`2e3e478\` 2024-05-01 — Ignoring build files
-- \`e8ff89e\` 2024-05-01 — Ignoring build files
-- \`1b1f9f3\` 2025-02-20 — New functions implemented (to be checked) in optical conductivity, local densities, mean square displacement, quantum metric...
-- \`7fa8ba5\` 2025-02-20 — The version with new functions clean
+| Feature | Class | Evidence |
+|---|---|---|
+| Optical / AC conductivity | A | `main`: `opticalConductivityFromChebmom.cpp`, `chebyshev_momentsAC.cpp`, `optical_conductivity_tools.hpp` |
+| Local DOS / local densities | A | `main`: `inline_compute-kpm-LocalDOS.cpp`, `localDensitiesFromChebmom.cpp`, `chebyshev_momentsLocal.cpp` |
+| Mean-square displacement | A | `main`: `MSD_Evolve`, `MeanSquareDisplacement_Graphene_NNN`, `inline_compute-kpm-MeanSquareDisplacement_DeviceSim.cpp` |
+| Time-evolution inline variants (`TimeEvOp`, `TimeEvProjetedOp`, `GetDeltaPhi`, `spacialresolution`) | A? | `main` has projected time-evolution (`inline_compute-kpm-TimeEvProjetedOp-Projecting_WF.cpp`); confirm these specific entry points are covered |
+| **Quantum metric** | **C** | absent from `main` — **but no identifiable `metric`/geometric-tensor source exists on this branch either** (named only in the commit message) |
 
-</details>
+- [ ] **Quantum metric:** confirm whether a real implementation exists (here, or
+      in the author's reference). If it exists, port to `main`'s interfaces,
+      verify (positive semi-definite output on a known model), then merge. If it
+      does not, it is a *new feature to implement*, not a merge.
+- [ ] Confirm the time-evolution inline entry points are functionally covered by
+      `main`; if any is genuinely new and verifiable, merge it; else drop.
 
-### `python_supported` — d49bc58 (2022-03-27), 11 commit(s) not in `main`
+### `python_supported` — `d49bc58` (2022-03-27)
 
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
+| Feature | Class | Evidence |
+|---|---|---|
+| Spin-projection operator | A | `main`: `spin_project(...)` in `Device/Graphene_NNN.cpp`, `Device/Graphene_KaneMele.cpp` |
+| Projected time-evolution operator | A | `main`: `inline_compute-kpm-TimeEvProjetedOp-Projecting_WF.cpp`, `time_evolution` namespace |
+| Python interface / `wannier2sparse` bindings / `band_processing.py` / plotting | C (interface) | 2020–22 layer; will not build against current `main` as-is |
 
-<details><summary>unique commits</summary>
+- [ ] **Restore Python interface:** decide whether to revive the pybind11
+      bindings and tooling against current `main`. This is an *interface* task,
+      not a numerics merge — port and confirm it builds before adopting; do not
+      merge broken bindings.
 
-- \`14f461a\` 2020-07-27 — In this branch we included some python supported modules
-- \`2b6e855\` 2020-07-27 — fix the python2.X problem and add example of wannier2sparse module
-- \`e033a0b\` 2020-08-26 — Added onsite_spinor function in wannier2sparse
-- \`465883f\` 2020-09-17 — Added the spin projection operator to the operators to be obtained from the wannier system
-- \`09da47e\` 2020-09-18 — Merge pull request #3 from AngelDPS/python_supported
-- \`f9d571a\` 2020-09-26 — Implemented a program for time evolution projected operator exp val
-- \`e18b184\` 2020-10-05 — Rearanged the order of the operators for the expression <Psi|PRJ U OP delta U PRJ|Psi>
-- \`182db75\` 2020-10-28 — Merge pull request #4 from AngelDPS/python_supported
-- \`bfad86d\` 2020-11-24 — improve the plotting scripts
-- \`eb96997\` 2021-01-30 — added band_processing.py
-- \`d49bc58\` 2022-03-27 — Hotfix for the spin operators, and update on changed files
+### `alpha_release` — `2bc3df6` (2020-02-12)  ·  `beta_release` — `b2eeb8e` (2020-03-10)
 
-</details>
+2020 feature branches. Headline physics is already in `main`:
 
-### `kpm_cuda` — d590ed7 (2019-10-23), 1 commit(s) not in `main`
+| Feature | Class | Evidence |
+|---|---|---|
+| Torque support (`beta_release`) | A | `main`: `createTorqueMatrix`, `createHoppingTorqueDensity_list` in `utilities/wannier2sparse/src/tbmodel.cpp` |
+| Disorder (`beta_release`) | A | `main`: Anderson disorder + electron-hole puddles in `Graphene_NNN` |
+| New current operators (`alpha_release`) | A | `main` has the full Kubo–Bastin/Greenwood current machinery (`currentTm`, `resetCurrentTm`, FFT solvers) |
+| Electric-field input option (`alpha_release`) | C? | not clearly present in `main` as a discrete input flag — **only open item** |
+| Fat-node / large-memory / high-memory mode | B | optimisation — out of scope |
+| Parallel Kubo-Bastin, cmake/README fixes | B | infra — out of scope |
 
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
-
-<details><summary>unique commits</summary>
-
-- \`d590ed7\` 2019-10-23 — This is the sofware I used for my PhD
-
-</details>
-
-### `TB-QuantumTransp` — 6a6c976 (2019-10-23), 1 commit(s) not in `main`
-
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
-
-<details><summary>unique commits</summary>
-
-- \`6a6c976\` 2019-10-23 — This is a old code where I try to implement domain decomposition
-
-</details>
-
-### `alpha_release` — 2bc3df6 (2020-02-12), 6 commit(s) not in `main`
-
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
-
-<details><summary>unique commits</summary>
-
-- \`1abfeed\` 2020-01-18 — include new current operators, include a testing vector os kubobastinfromchebmom parallel
-- \`d5f214e\` 2020-01-18 — add option for changn the electric field
-- \`5678cb8\` 2020-01-20 — add support for high-memory calculations
-- \`42baee3\` 2020-01-29 — Fix cmake file
-- \`5f48a88\` 2020-02-12 — Create README.md
-- \`2bc3df6\` 2020-02-12 — Update README.md
-
-</details>
-
-### `beta_release` — b2eeb8e (2020-03-10), 5 commit(s) not in `main`
-
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
-
-<details><summary>unique commits</summary>
-
-- \`fe5b00f\` 2020-02-20 — include support of torque
-- \`8e455e5\` 2020-02-21 — Fix large memory problems
-- \`eac8ef6\` 2020-02-27 — added full fatnode support
-- \`708f42a\` 2020-02-28 — added disorder support
-- \`b2eeb8e\` 2020-03-10 — Fix compilation issues
-
-</details>
-
-### `new_currents` — 5678cb8 (2020-01-20), 3 commit(s) not in `main`
-
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
-
-<details><summary>unique commits</summary>
-
-- \`1abfeed\` 2020-01-18 — include new current operators, include a testing vector os kubobastinfromchebmom parallel
-- \`d5f214e\` 2020-01-18 — add option for changn the electric field
-- \`5678cb8\` 2020-01-20 — add support for high-memory calculations
-
-</details>
-
-### `stable` — 0210d1a (2019-10-23), 1 commit(s) not in `main`
-
-- [ ] Review against `main`
-- [ ] Validate against reference implementation/results
-
-<details><summary>unique commits</summary>
-
-- \`0210d1a\` 2019-10-23 — The stable version of my code 0.0.0
-
-</details>
-
+- [ ] Confirm the **electric-field input option** is covered by `main`'s
+      conductivity machinery. If genuinely missing and worth having, port +
+      verify + merge; otherwise these two branches are fully superseded and may
+      be deleted (`archive/alpha_release`, `archive/beta_release` retain them).


### PR DESCRIPTION
Per-feature evaluation of every kept branch against `main`.

**Finding:** `main` already implements essentially all the KPM physics from the old branches (optical/AC conductivity, local DOS/densities, MSD, torque, disorder, current operators, spin-projection & projected time-evolution operators, non-orthogonal solver). Nothing met the merge bar — and the env had no MKL/GSL to build+smoke-test — so **nothing was merged into main** (per 'never merge unverifiable; doubt → roadmap').

**Branch cleanup (archive/* tags retained for all):**
- Deleted `kpm_cuda`, `TB-QuantumTransp` — GPU/parallel, out of scope (step 0).
- Deleted `master` (nonOrth superseded), `stable` (legacy), `new_currents` (subset of alpha_release).

**Open items kept in ROADMAP.md:** quantum metric (New_functions), Python interface (python_supported), electric-field input option (alpha/beta_release).

This PR only updates `ROADMAP.md`.