### PR TITLE
Activate Hermiticity guard on CSR read; document full-matrix fold

### DIFF
--- a/src/eigen_sparse_matrix.cpp
+++ b/src/eigen_sparse_matrix.cpp
@@ -39,6 +39,8 @@ void SparseMatrixType::ConvertFromCOO(vector<indexType> &rows, vector<indexType>
 
 #include <cmath>
 #include <numeric> // For std::accumulate
+#include <stdexcept> // std::runtime_error (Hermiticity guard)
+#include <algorithm> // std::max
 
 
 double compute_norm(const std::vector<complex<double>>& vec) {
@@ -121,13 +123,30 @@ void SparseMatrixType::ConvertFromCSR(vector<indexType> &cols, vector<indexType>
 	
 	//Eigen::SelfAdjointView<Eigen::SparseMatrix<double>, Eigen::Upper> symmetric_view(sparse_matrix);// ->Maybe saves half the memory? Couldnt see the documentation
 
-	std::cout<<"We are no longer assuming a triangular matrix here!"<<std::endl;
-	//std::cout<<"We are assuming a triangular matrix here! considering the bottom triangle as filled with 0s. We are adding the adjoint to the Hamiltonian"<<std::endl;
-	Eigen::SparseMatrix<complex<double>, Eigen::RowMajor, indexType> transp = Eigen::SparseMatrix<complex<double>, Eigen::RowMajor, indexType>( matrix_.adjoint() ); 
-	//if( ( transp - matrix_ ).norm() != 0 ){
-	//std::cout<<"Hamiltonian has to be symmetrized."<<std::endl;
-	matrix_ =  0.5 * (transp + matrix_); 
-	  //}
+	// --- Hermiticity guard: validate the RAW input before folding ---
+	// Computed on matrix_ as read, before the H = 0.5*(M + M^dagger) fold below.
+	const double num = (matrix_ - Eigen::SparseMatrix<complex<double>, Eigen::RowMajor, indexType>(matrix_.adjoint())).norm();
+	const double den = std::max(matrix_.norm(), 1e-300);
+	const double herm_res = num / den;
+	const double herm_tol = 1e-8;
+	if (herm_res > herm_tol) {
+		std::cerr << "[CSR] non-Hermitian input: ||M-M^H||/||M|| = " << herm_res
+		          << " (tol " << herm_tol << "). Likely an upper-triangle file read "
+		             "under the full-matrix convention; off-diagonals would be halved."
+		          << std::endl;
+		throw std::runtime_error("ConvertFromCSR: non-Hermitian CSR input under full-matrix convention");
+	}
+
+	// Input CSR is the FULL Hermitian operator. Fold to enforce/clean Hermiticity:
+	//   H = 0.5*(M + M^dagger)   (identity for an exactly-Hermitian M).
+	// A large self-adjointness residual ||M - M^dagger|| / ||M|| means the producer
+	// wrote a half/triangle matrix under the full convention (off-diagonals would be
+	// silently halved) -> fail rather than corrupt; see the assertion above.
+	// Do NOT reintroduce a plain "U + U^dagger" path: on a diagonal-bearing triangle it
+	// doubles the on-site terms. A real triangle mode must use U + U^dagger - diag(U)
+	// and be selected by an explicit storage tag, never assumed.
+	Eigen::SparseMatrix<complex<double>, Eigen::RowMajor, indexType> transp = Eigen::SparseMatrix<complex<double>, Eigen::RowMajor, indexType>( matrix_.adjoint() );
+	matrix_ =  0.5 * (transp + matrix_);
 
 	
 


### PR DESCRIPTION
Documents the CSR fold contract and **activates an assertive Hermiticity guard** in `ConvertFromCSR`, so a half/triangle file read under the full-matrix convention fails loudly instead of silently halving every off-diagonal hopping (the original bug).

**Guard** (on the RAW input, before the fold; named tolerance `herm_tol = 1e-8`):
`||M − M^H|| / ||M|| > herm_tol` → `std::cerr` + `throw std::runtime_error`.

- The fold `H = 0.5*(M + M†)` is **unchanged**.
- Removed the narrating `cout` and commented `U+U†` remnants (the diagonal-doubling path) so it can't be resurrected; added a precise contract comment.

**Verified:** builds clean (Eigen backend). Positive: full Hermitian operators → guard silent, driver completes. Negative: an upper-triangle HAM (nnz 1872→1008) trips the guard (`||M-M^H||/||M|| = 1.41`) and aborts before computing — exactly the bug it's meant to catch.

**No-op for valid input:** the fold statements are textually unchanged and the guard is read-only (residual ≈ 0 → no throw). Note: a literal bit-identical *moment-file* diff requires deterministic RNG (the `KPM_SEED` fix is on the unmerged decouple-goldens branch); on `main` the generator is time-seeded, so moment files vary run-to-run independent of this change.

`--storage full|upper` left as design spec only; not implemented.