### PR TITLE
Phase 2: fix Bug 1 — Kubo-Greenwood prefactor (ShiftFactor → ScaleFactor)

### DIFF
--- a/src/kuboGreenwoodFromChebmom.cpp
+++ b/src/kuboGreenwoodFromChebmom.cpp
@@ -68,7 +68,16 @@ int main(int argc, char *argv[])
 		for( int m1 = 0 ; m1 < mu.HighestMomentNumber(1) ; m1++)
 			out += delta_chebF(energ,m0)*( greenR_chebF(energ,m1)*mu(m0,m1) ).imag() ;
 		
-		kernel[i] =  -1.0*out*(mu.SystemSize()*mu.ScaleFactor()*mu.ShiftFactor() );
+		// Bug 1 fix: the second factor was ShiftFactor(), which is
+		// -BandCenter/HalfWidth*CUTOFF = 0 for any band centred at E=0 (clean chain,
+		// graphene, every particle-hole-symmetric system) -> sigma_KG was identically 0.
+		// It must be a second ScaleFactor(): the Kubo-Greenwood prefactor is
+		// -SystemSize*ScaleFactor^2 (half the Kubo-Bastin -2*SystemSize*ScaleFactor^2,
+		// since Bastin's Fermi-sea term doubles the surface term). Calibrated on a
+		// disordered chain (W=1, exact trace): Greenwood sigma_xx(E) then matches the
+		// Chern-validated Bastin route to ~5%, and the magnitude (~40 e^2/h) agrees with
+		// the Drude estimate. ShiftFactor() remains the energy-axis shift only (below).
+		kernel[i] =  -1.0*out*(mu.SystemSize()*mu.ScaleFactor()*mu.ScaleFactor() );
 	}
 
 	for( int i=0; i < num_div-1; i++)


### PR DESCRIPTION
## Summary
Fixes **Bug 1**: `kuboGreenwoodFromChebmom.cpp:71` multiplied the kernel by
`ScaleFactor()·ShiftFactor()`. `ShiftFactor() = -BandCenter/HalfWidth·CUTOFF` is **exactly 0**
for any band centred at E=0 — the clean chain, graphene, every particle-hole-symmetric
system — so **σ_KG came out identically zero**.

The second factor must be a second `ScaleFactor()`: the Kubo-Greenwood prefactor is
`-SystemSize·ScaleFactor²`, i.e. half the Kubo-Bastin `-2·SystemSize·ScaleFactor²` (Bastin's
Fermi-sea term doubles the Fermi-surface contribution). The leading `-1.0` was already
correct — only the typo'd `ShiftFactor` becomes `ScaleFactor`. `ShiftFactor()` still appears,
correctly, on the **output energy axis** (line 75).

## Calibration
Per the plan, calibrated on a **disordered** chain (W=1, N=512, exact trace, M=512) — *not*
the clean chain (no DC limit):
- Greenwood σ_xx(E) now matches the **Chern-validated** Kubo-Bastin route to **~5%** across
  the band (B/G = 0.92–1.09; was 0/0 before).
- Absolute magnitude: intensive **σ_xx(0) ≈ 40 e²/h**, consistent with the Drude–Born
  estimate ~48/W².

## Validation
- **ctest 6/6** unchanged (no Greenwood golden in the suite).
- Greenwood reconstruction of the committed graphene moments is now non-zero (σ_KG ≈ 1.08 at
  E≈0.6, was 0.0).

Note: on `main` the Greenwood `.dat` still has band-edge NaN — that is the separate **Bug 2**,
fixed by the α safeguard in #18; the two changes compose (non-zero **and** finite).

⚠️ Touches reconstruction physics / scales — **do not auto-merge; reserved for review** per
the implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)