### PR TITLE
Phase 0: Kubo-Greenwood reconstruction regression (pins Bug 1, σ_KG≠0)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,3 +138,11 @@ add_test(NAME spin_precession
 add_executable(recon_kernel_oracle_test recon_kernel_oracle_test.cpp)
 target_include_directories(recon_kernel_oracle_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME recon_kernel_oracle COMMAND recon_kernel_oracle_test 0.10)
+
+# --- Kubo-Greenwood reconstruction regression (Bug 1, Phase 0) -------------------
+# Pins PR #19: kuboGreenwoodFromChebmom multiplied by ShiftFactor() (==0 for centred bands)
+# so sigma_KG was identically 0. chain1d_analytic/graphene_regression guard MOMENTS, not the
+# reconstruction prefactor -- a regression to sigma_KG==0 would pass CI silently. This asserts
+# the reconstructed sigma_KG(E) from the committed graphene moments is finite and non-zero.
+add_test(NAME greenwood_regression
+         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/greenwood_regression.sh ${CMAKE_BINARY_DIR})

--- a/test/greenwood_regression.sh
+++ b/test/greenwood_regression.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Kubo-Greenwood reconstruction regression -- pins the Bug-1 fix (Phase 0).
+#
+# Bug 1 (fixed in PR #19): kuboGreenwoodFromChebmom.cpp multiplied the kernel by
+# ScaleFactor()*ShiftFactor(); ShiftFactor() = -BandCenter/HalfWidth*CUTOFF is identically 0
+# for any band centred at E=0 (clean chain, graphene, every particle-hole-symmetric system),
+# so sigma_KG came out IDENTICALLY ZERO. The fix makes the second factor a second ScaleFactor()
+# (prefactor -SystemSize*ScaleFactor^2).
+#
+# Coverage gap this closes: chain1d_analytic guards the KG *moment matrix* (B.15) and
+# graphene_regression guards the *moments* -- but NEITHER exercises the reconstruction
+# prefactor, so a regression back to sigma_KG==0 would pass CI silently. This test reconstructs
+# sigma_KG(E) from the committed graphene VX-VX moments and asserts it is FINITE and NOT
+# identically zero in the band interior (the bug gives exactly 0 everywhere; the fix gives
+# O(1)). Reference is the physical fact that a centred metal's longitudinal conductivity is not
+# identically zero -- not another run.
+#
+# Usage: greenwood_regression.sh <BUILD_DIR>
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$(cd "${1:-$REPO/build}" && pwd)"
+DRV="$BUILD/inline_kuboGreenwoodFromChebmom"
+GMOM="$REPO/test/golden/NonEqOpVX-VXgraphene_goldenKPM_M64x64_statedefault.chebmom2D"
+
+[ -x "$DRV" ] || { echo "FAIL: Kubo-Greenwood driver missing ($DRV)"; exit 1; }
+[ -f "$GMOM" ] || { echo "FAIL: committed graphene VX-VX moments missing ($GMOM)"; exit 1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+cp "$GMOM" "$T/"
+( cd "$T"
+  MOM="$(ls *.chebmom2D | head -1)"
+  "$DRV" "$MOM" 10 >driver.log 2>&1 \
+    || { echo "FAIL: Kubo-Greenwood reconstruction crashed"; cat driver.log; exit 1; }
+  DAT="$(ls KuboGreenWood_*.dat 2>/dev/null | head -1)"
+  [ -n "$DAT" ] || { echo "FAIL: no reconstruction .dat produced"; cat driver.log; exit 1; }
+
+  # Finite everywhere, and a non-negligible interior magnitude (the bug => exactly 0).
+  NANS=$(awk 'tolower($2) ~ /nan|inf/ {c++} END{print c+0}' "$DAT")
+  MAXABS=$(awk 'function abs(x){return x<0?-x:x}
+                tolower($2) !~ /nan|inf/ && abs($1) < 2.0 {if(abs($2)>m)m=abs($2)} END{printf "%.6g", m+0}' "$DAT")
+  echo "interior max|sigma_KG| = $MAXABS   (NaN/Inf rows = $NANS)"
+  [ "$NANS" -eq 0 ] || { echo "FAIL: $NANS NaN/Inf rows in the Greenwood reconstruction"; exit 1; }
+  awk -v m="$MAXABS" 'BEGIN{ if (m > 1e-3) exit 0; else exit 1 }' \
+    || { echo "FAIL: sigma_KG is ~0 in the interior (max|sigma_KG|=$MAXABS) -- Bug 1 regressed (ShiftFactor)"; exit 1; }
+  echo "PASS: Kubo-Greenwood sigma_KG(E) is finite and non-zero (Bug 1 fix intact)"
+)


### PR DESCRIPTION
## Summary
Closes the coverage hole flagged in the v2 review: **Bug 1's fix (PR #19) was unpinned.**

Bug 1 made `kuboGreenwoodFromChebmom` multiply the kernel by `ShiftFactor()` (≡0 for
centred bands), so σ_KG was **identically zero**. The fix (a second `ScaleFactor()`) is merged,
but no test exercised the reconstruction prefactor — `chain1d_analytic` guards the KG *moment
matrix* (B.15) and `graphene_regression` guards the *moments*, so a regression back to σ_KG≡0
would pass CI silently.

**`greenwood_regression`** reconstructs σ_KG(E) from the committed graphene VX-VX moments and
asserts it is **finite and not identically zero** in the band interior (the bug → exactly 0
everywhere; the fix → O(1)).

## Verified as a true regression gate
- ShiftFactor bug **reintroduced** → test **FAILS** (`interior max|σ_KG|=0 … Bug 1 regressed`)
- fix **restored** → test **PASSES**

Reference is the physical fact that a centred metal's longitudinal conductivity is not
identically zero — not another run. **ctest 12/12 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)