### PR TITLE
Refactor Phase 1: named safety factors + runtime α + single HBAR home

### DIFF
--- a/include/chebyshev_moments.hpp
+++ b/include/chebyshev_moments.hpp
@@ -29,28 +29,19 @@
 #include "vector_list.hpp"
 #include "special_functions.hpp"
 #include "chebyshev_coefficients.hpp"
+#include "units.hpp"        // chebyshev::HBAR (single home for the eV*fs time unit)
+#include "recon_grid.hpp"   // chebyshev::safety_factors(): recon_cutoff (alpha) + bounds_pad
 
-namespace chebyshev 
+namespace chebyshev
 {
+	// CUTOFF — the MOMENT rescale cutoff. SACRED at 1.00: the band must fill the Chebyshev
+	// domain [-1,1] EXACTLY for the analytic moment identities (DOS moments = delta_{m,0},
+	// Kubo-Greenwood matrix = B.15). It feeds ScaleFactor()/ShiftFactor() ONLY.
+	//
+	// The reconstruction-grid cutoff (alpha) and the Gershgorin bounds pad are SEPARATE,
+	// runtime-tunable knobs -- see chebyshev::safety_factors() in recon_grid.hpp. alpha must
+	// NEVER enter ScaleFactor()/ShiftFactor() (guarded by the safety_factors_guard test).
 	const double CUTOFF = 1.00;
-
-	// KPM_ALPHA — the reconstruction-grid safety cutoff (the "alpha" safeguard).
-	//
-	// The Hamiltonian moments are rescaled so the band fills the Chebyshev domain
-	// [-1, 1] exactly (CUTOFF = 1.00 above); this is required for the analytic moment
-	// identities (DOS moments = delta_{m,0}, Kubo-Greenwood matrix = B.15) to hold.
-	//
-	// The *reconstruction* step is different: the kernels carry 1/sqrt(1 - x^2)
-	// (delta_chebF, greenR_chebF, DgreenR_chebF in chebyshev_coefficients.hpp), which
-	// is NaN at x = +-1. A uniform reconstruction grid that reaches +-1, or an FFT
-	// integration that runs all the way to the band edge, hits that singularity and
-	// (for the cumulative Kubo-Bastin integral) poisons the whole curve with NaN.
-	//
-	// Fix: reconstruct only on [-alpha, alpha] with alpha = 0.95 < 1, so the grid never
-	// touches the singularity. Decoupled from CUTOFF on purpose: moments stay at [-1, 1]
-	// (oracle-exact), only the reconstruction grids/edge use alpha. The FFT route uses
-	// the complementary cushion safety_epsilon = 1 - KPM_ALPHA.
-	const double KPM_ALPHA = 0.95;
 
 class Moments
 {
@@ -330,7 +321,6 @@ class Moments2D: public Moments
            SparseMatrixType* _pNCON, *_VX, *_VY;
         
 	  public:
-	  const double HBAR = 0.6582119624 ;//planck constant in eV.fs
 	 
 
 
@@ -726,7 +716,6 @@ class Vectors_sliced_nonOrthogonal : public Vectors_sliced
 	  private:
 		SparseMatrixType* _pNCON;
 	  public:
-	  const double HBAR = 0.6582119624 ;//planck constant in eV.fs
 	 
 
 

--- a/include/chebyshev_moments_Device.hpp
+++ b/include/chebyshev_moments_Device.hpp
@@ -6,6 +6,7 @@
 #include <complex>
 #include <vector>
 #include <string>
+#include "units.hpp"
 #include <array>
 
 #include "sparse_matrix.hpp" //contain SparseMatrixType
@@ -280,7 +281,6 @@ class Moments2D_Device: public Moments_Device
 	  private:
 		SparseMatrixType* _pNCON;
 	  public:
-	  const double HBAR = 0.6582119624 ;//planck constant in eV.fs
 	 
 
 

--- a/include/chebyshev_moments_Graphene_NNN.hpp
+++ b/include/chebyshev_moments_Graphene_NNN.hpp
@@ -6,6 +6,7 @@
 #include <complex>
 #include <vector>
 #include <string>
+#include "units.hpp"
 #include <array>
 
 #include "sparse_matrix.hpp" //contain SparseMatrixType
@@ -280,7 +281,6 @@ class Moments2D_Graphene_NNN: public Moments_Graphene_NNN
 	  private:
 		SparseMatrixType* _pNCON;
 	  public:
-	  const double HBAR = 0.6582119624 ;//planck constant in eV.fs
 	 
 
 

--- a/include/recon_grid.hpp
+++ b/include/recon_grid.hpp
@@ -3,10 +3,50 @@
 
 #include <cstdlib>   // getenv, atof
 
+// ============================================================================================
+// THREE distinct cutoff/margin constants live in the KPM pipeline. They are easy to confuse
+// because all three are "numbers near 1 that keep things inside [-1,1]", but they act at
+// DIFFERENT stages, on DIFFERENT quantities, with DIFFERENT correct values. Do NOT merge them.
+//
+//   name          value  where it lives               stage / what it scales
+//   -----------   -----  --------------------------   ---------------------------------------
+//   CUTOFF         1.00  chebyshev_moments.hpp         MOMENT RESCALE. ScaleFactor()=CUTOFF/
+//                        (chebyshev::CUTOFF)           HalfWidth(); ShiftFactor()=-BandCenter/
+//                                                      HalfWidth()*CUTOFF. Maps H -> H~ so the
+//                                                      band fills [-1,1]. *** SACRED = 1.00 ***:
+//                                                      the analytic moment identities (DOS
+//                                                      moments delta_{m,0}, KG matrix B.15) hold
+//                                                      ONLY at exact fill. Lowering it under-fills
+//                                                      the domain and moves every moment (oracle
+//                                                      residual 0.05-0.375 vs tol 1e-9).
+//
+//   recon_cutoff   0.95  recon_grid.hpp (this file)    RECONSTRUCTION GRID (alpha). The energy
+//   (alpha)              safety_factors().recon_cutoff grid runs on [-alpha,alpha] (uniform
+//                                                      route) or with edge cushion 1-alpha (FFT
+//                                                      route). Keeps the grid off the 1/sqrt(1-x^2)
+//                                                      reconstruction-kernel singularity at x=+-1
+//                                                      (the Kubo-Bastin all-NaN band edge).
+//                                                      Runtime-tunable; alpha=1.0 reproduces the
+//                                                      legacy/edge-unsafe grid. NEVER touches moments.
+//
+//   bounds_pad     0.10  recon_grid.hpp (this file)    SPECTRAL-BOUNDS ESTIMATE. Fractional margin
+//                        safety_factors().bounds_pad   on the Gershgorin enclosure of H (used only
+//                                                      when no BOUNDS file): bounds = +-rho*(1+
+//                                                      bounds_pad). Ensures H~ stays in [-1,1] so
+//                                                      the Chebyshev RECURSION is stable. It widens
+//                                                      the *band estimate*, not the recon grid.
+//
+// Mental model: CUTOFF sets how the band maps INTO the Chebyshev domain (moments); bounds_pad
+// makes the band *estimate* conservative enough that the recursion never leaves the domain;
+// recon_cutoff sets how far OUT toward the domain edge we dare to reconstruct. Coupling any two
+// of them is a bug -- the safety_factors_guard test fails if alpha leaks into ScaleFactor().
+// ============================================================================================
+
 namespace chebyshev
 {
 	// Two DISTINCT, named safety factors. Deliberately NOT a single "alpha": they do different
-	// jobs, live at different points, and have different correct values.
+	// jobs, live at different points, and have different correct values (see the table above;
+	// CUTOFF is the third constant and lives, sacred at 1.00, in chebyshev_moments.hpp).
 	struct SafetyFactors
 	{
 		// recon_cutoff (alpha): the reconstruction grid runs on [-alpha, alpha] (or, for the

--- a/include/recon_grid.hpp
+++ b/include/recon_grid.hpp
@@ -1,0 +1,48 @@
+#ifndef LSQUANT_RECON_GRID
+#define LSQUANT_RECON_GRID
+
+#include <cstdlib>   // getenv, atof
+
+namespace chebyshev
+{
+	// Two DISTINCT, named safety factors. Deliberately NOT a single "alpha": they do different
+	// jobs, live at different points, and have different correct values.
+	struct SafetyFactors
+	{
+		// recon_cutoff (alpha): the reconstruction grid runs on [-alpha, alpha] (or, for the
+		// FFT route, with an edge cushion 1 - alpha). It keeps the grid off the 1/sqrt(1-x^2)
+		// reconstruction-kernel singularity at x = +-1 -- the band-edge NaN that poisoned the
+		// cumulative Kubo-Bastin integral. Default 0.95.
+		//
+		//   *** NOT a moment knob. *** The moment rescale stays at CUTOFF = 1.00 (the band must
+		//   fill [-1,1] EXACTLY for the analytic moment identities -- DOS moments delta_{m,0},
+		//   Kubo-Greenwood matrix B.15). Under-filling to [-alpha,alpha] in moments moves every
+		//   moment and breaks the oracle (residual 0.05-0.375 vs tol 1e-9). alpha = 1.0 selects
+		//   the legacy moment-identity reconstruction grid.
+		double recon_cutoff;
+
+		// bounds_pad: fractional margin added to the Gershgorin spectral-bounds estimate so the
+		// rescaled spectrum stays inside [-1,1] (Chebyshev recursion stability). This is the
+		// estimator's safety margin, independent of recon_cutoff. Default 0.10.
+		double bounds_pad;
+	};
+
+	// Process-wide safety factors, resolved ONCE. Defaults reproduce the shipped goldens
+	// bit-for-bit. Override at runtime via environment -- the Phase-1 "alpha as a first-class
+	// runtime parameter" step; Phase 4 will route these through run.json:
+	//   LSQUANT_RECON_ALPHA  -> recon_cutoff   (e.g. 1.0 for the legacy/edge-unsafe grid)
+	//   LSQUANT_BOUNDS_PAD   -> bounds_pad
+	inline const SafetyFactors& safety_factors()
+	{
+		static const SafetyFactors sf = []
+		{
+			SafetyFactors s{ 0.95, 0.10 };
+			if (const char* a = std::getenv("LSQUANT_RECON_ALPHA")) s.recon_cutoff = std::atof(a);
+			if (const char* p = std::getenv("LSQUANT_BOUNDS_PAD"))  s.bounds_pad   = std::atof(p);
+			return s;
+		}();
+		return sf;
+	}
+}
+
+#endif // LSQUANT_RECON_GRID

--- a/include/units.hpp
+++ b/include/units.hpp
@@ -1,0 +1,19 @@
+#ifndef LSQUANT_UNITS
+#define LSQUANT_UNITS
+
+namespace chebyshev
+{
+	// Reduced Planck constant, in eV*fs -- the SOLE home for the time-evolution unit.
+	//
+	// The Chebyshev/Bessel propagator advances PHYSICAL time t (in fs): the per-step
+	// frequency is ChebyshevFreq() = HalfWidth/CUTOFF/HBAR, so e.g. spin precession runs at
+	// omega = 2*J_ex/HBAR rad/fs (period 2*pi*HBAR/(2 J_ex)), NOT the hbar=1 convention of the
+	// static moment oracle. See docs/spectral_scales.md section 5.
+	//
+	// This value was hard-coded x5 (twice in chebyshev_moments.hpp, plus the _Device and
+	// _Graphene_NNN forks and chebyshev_solver.cpp). Consolidated here; the forks include this
+	// header now and the duplicate copies disappear when the forks merge in Phase 6.
+	inline constexpr double HBAR = 0.6582119624; // eV*fs
+}
+
+#endif // LSQUANT_UNITS

--- a/src/Kubo_solver_FFT_postProcess.cpp
+++ b/src/Kubo_solver_FFT_postProcess.cpp
@@ -54,7 +54,7 @@ void Kubo_solver_FFT_postProcess::integration(const r_value_t E_points[], const 
   int M     = parent_solver_.num_vectors(),
       nump = parent_solver_.nump();
   
-  r_value_t edge = 1.0 - chebyshev::KPM_ALPHA;//parameters_.edge_;
+  r_value_t edge = 1.0 - chebyshev::safety_factors().recon_cutoff;//parameters_.edge_;
 
   //#pragma omp parallel for 
   for(int k=0; k<nump - int( M * edge / 4.0 ); k++ ){  //At the very edges of the energy plot the weight function diverges, hence integration should start a little after and a little before the edge.

--- a/src/chebyshev_solver.cpp
+++ b/src/chebyshev_solver.cpp
@@ -1,5 +1,7 @@
 // Used for OPENMP functions
 #include "chebyshev_solver.hpp"
+#include "units.hpp"
+#include "recon_grid.hpp"
 #include <eigen3/Eigen/Core>
 #include <boost/math/special_functions/bessel.hpp>
 
@@ -40,7 +42,7 @@ std::vector<cdouble> chebyshev::calculate_cn_bessel(double T, double ac, double 
     std::cout << "\nCalculating the Chebyshev expansion coefficients...\n";
 
 
-    const double hbar    =  0.6582119624;// eV·fs
+    const double hbar    =  chebyshev::HBAR;// eV*fs (units.hpp)
     const cdouble minus_i  = cdouble(0.0, -1.0);
     const cdouble phase     = std::exp(minus_i * (bc/ac) * T / hbar);   // exp(-i*ac*T)
     const double  bessel_arg =  T * ac / hbar;
@@ -476,7 +478,7 @@ std::array<double,2> utility::SpectralBounds( SparseMatrixType& HAM)
 	}
 	else
 	{
-		const double PAD = 0.10; // 10% safety margin on the Gershgorin enclosure
+		const double PAD = chebyshev::safety_factors().bounds_pad; // Gershgorin enclosure margin (recon_grid.hpp)
 		auto& mat = HAM.eigen_matrix();
 		double rho = 0.0;        // max absolute row sum = ||H||_inf >= spectral radius
 		for (int r = 0; r < mat.outerSize(); ++r)

--- a/src/inline_kpm-DOS-standalone.cpp
+++ b/src/inline_kpm-DOS-standalone.cpp
@@ -123,7 +123,7 @@ void postProcess(chebyshev::Moments1D& mu ){
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/inline_kpm-DOS-standalone_Graphene_NNN.cpp
+++ b/src/inline_kpm-DOS-standalone_Graphene_NNN.cpp
@@ -137,7 +137,7 @@ void postProcess(chebyshev::Moments1D_Graphene_NNN& mu ){
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/inline_kpm-S-inversion.cpp
+++ b/src/inline_kpm-S-inversion.cpp
@@ -121,7 +121,7 @@ void postProcess(chebyshev::Moments1D& mu ){
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboBastinFromChebmom.cpp
+++ b/src/kuboBastinFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboBastinFromChebmom_FFTgrid.cpp
+++ b/src/kuboBastinFromChebmom_FFTgrid.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 	const int num_div = mu.HighestMomentNumber();
 	
 	const double
-	  xbound = chebyshev::KPM_ALPHA,
+	  xbound = chebyshev::safety_factors().recon_cutoff,
 	  disp = 0.5;
 		
 	std::vector< double >  energies(num_div,0);

--- a/src/kuboBastinIFromChebmom.cpp
+++ b/src/kuboBastinIFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboBastinIIFromChebmom.cpp
+++ b/src/kuboBastinIIFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboBastinSeaFromChebmom.cpp
+++ b/src/kuboBastinSeaFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboBastinSurfFromChebmom.cpp
+++ b/src/kuboBastinSurfFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboGreenwoodFromChebmom.cpp
+++ b/src/kuboGreenwoodFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/kuboGreenwoodFromChebmom_FFTgrid.cpp
+++ b/src/kuboGreenwoodFromChebmom_FFTgrid.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = mu.HighestMomentNumber(); //This should be taking nump
 	
 	const double
-	  xbound = chebyshev::KPM_ALPHA,
+	  xbound = chebyshev::safety_factors().recon_cutoff,
 	  disp = 0.5;
 		
 	std::vector< double >  energies(num_div,0);

--- a/src/spectralFunctionFromChebmom.cpp
+++ b/src/spectralFunctionFromChebmom.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/src/spectralFunctionFromChebmom_FFTgrid.cpp
+++ b/src/spectralFunctionFromChebmom_FFTgrid.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	const int num_div = mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++){

--- a/src/spectralFunctionFromChebmom_Lorentz.cpp
+++ b/src/spectralFunctionFromChebmom_Lorentz.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 	const int num_div = 30*mu.HighestMomentNumber();
 	
 	const double
-	xbound = chebyshev::KPM_ALPHA;
+	xbound = chebyshev::safety_factors().recon_cutoff;
 		
 	std::vector< double >  energies(num_div,0);
 	for( int i=0; i < num_div; i++)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -146,3 +146,10 @@ add_test(NAME recon_kernel_oracle COMMAND recon_kernel_oracle_test 0.10)
 # the reconstructed sigma_KG(E) from the committed graphene moments is finite and non-zero.
 add_test(NAME greenwood_regression
          COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/greenwood_regression.sh ${CMAKE_BINARY_DIR})
+
+# --- Phase 1 safety-factor invariants (alpha decoupled, HBAR single, alpha runtime) ---
+# Guards: (1) ScaleFactor()/ShiftFactor() use CUTOFF only -- alpha must NEVER enter the moment
+# rescale (it would break the analytic moment identities); (2) the HBAR literal lives only in
+# units.hpp; (3) LSQUANT_RECON_ALPHA changes the reconstruction grid at runtime.
+add_test(NAME safety_factors_guard
+         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/safety_factors_guard.sh ${CMAKE_BINARY_DIR})

--- a/test/safety_factors_guard.sh
+++ b/test/safety_factors_guard.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Phase 1 invariant guard: the reconstruction cutoff (alpha) must stay OUT of the moment
+# rescale, HBAR must have a single home, and alpha must be a runtime parameter.
+#
+# Three checks:
+#   (1) SACRED MOMENT RESCALE. Every ScaleFactor()/ShiftFactor() definition uses a CUTOFF
+#       constant and NEVER the reconstruction cutoff (safety_factors / recon_cutoff / KPM_ALPHA /
+#       LSQUANT_RECON_ALPHA). Coupling alpha into the moment rescale under-fills [-1,1] and
+#       breaks the analytic moment identities (chain1d_analytic / chain1d_dos).
+#   (2) SINGLE HBAR. The literal 0.6582119624 appears only in include/units.hpp.
+#   (3) RUNTIME ALPHA. The reconstruction grid responds to LSQUANT_RECON_ALPHA at runtime:
+#       a larger alpha yields a wider reconstruction energy range (alpha reaches the grid).
+#
+# Usage: safety_factors_guard.sh <BUILD_DIR>
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$(cd "${1:-$REPO/build}" && pwd)"
+fail=0
+
+echo "[1] moment rescale (ScaleFactor/ShiftFactor) must use CUTOFF only, never alpha"
+defs=$(grep -rnE 'double (ScaleFactor|ShiftFactor)\(\) *const' "$REPO/include" || true)
+echo "$defs" | sed 's/^/    /'
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  if echo "$line" | grep -qiE 'recon_cutoff|safety_factors|KPM_ALPHA|RECON_ALPHA'; then
+    echo "    FAIL: alpha leaked into a moment-rescale factor: $line"; fail=1
+  fi
+  if ! echo "$line" | grep -qE 'CUTOFF'; then
+    echo "    FAIL: moment-rescale factor does not reference a CUTOFF constant: $line"; fail=1
+  fi
+done <<< "$defs"
+[ "$fail" -eq 0 ] && echo "    OK: moment rescale is CUTOFF-only (alpha decoupled)"
+
+echo "[2] HBAR single-sourced in include/units.hpp"
+hits=$(grep -rln '0\.6582119624' "$REPO/include" "$REPO/src" || true)
+echo "$hits" | sed 's/^/    /'
+nonunits=$(echo "$hits" | grep -v 'include/units.hpp' || true)
+if [ -n "$nonunits" ]; then echo "    FAIL: HBAR literal outside units.hpp:"; echo "$nonunits" | sed 's/^/      /'; fail=1
+else echo "    OK: only include/units.hpp carries the HBAR literal"; fi
+
+echo "[3] alpha is runtime (reconstruction energy range scales with LSQUANT_RECON_ALPHA)"
+GMOM="$REPO/test/golden/NonEqOpVX-VXgraphene_goldenKPM_M64x64_statedefault.chebmom2D"
+DRV="$BUILD/inline_kuboBastinFromChebmom"
+if [ -x "$DRV" ] && [ -f "$GMOM" ]; then
+  rng() { # max |E| of the reconstruction ENERGY axis (col 1, always finite) for a given alpha.
+          # Note col 2 (sigma) is all-NaN at alpha=1.0 -- that IS Bug 2, the reason alpha<1 ships.
+    local a="$1"; local T; T="$(mktemp -d)"; cp "$GMOM" "$T/"
+    ( cd "$T"; LSQUANT_RECON_ALPHA="$a" "$DRV" "$(ls *.chebmom2D)" 10 >/dev/null 2>&1
+      awk 'function abs(x){return x<0?-x:x} {if(abs($1)>m)m=abs($1)} END{printf "%.4f", m}' KuboBastin*.dat )
+    rm -rf "$T"
+  }
+  r95=$(rng 0.95); r100=$(rng 1.00)
+  echo "    max|E|: alpha=0.95 -> $r95 ;  alpha=1.00 -> $r100"
+  awk -v a="$r95" -v b="$r100" 'BEGIN{ if (b > a*1.02) exit 0; else exit 1 }' \
+    || { echo "    FAIL: alpha did not widen the grid at runtime (env not honored?)"; fail=1; }
+  [ "$fail" -eq 0 ] && echo "    OK: alpha=1.00 grid wider than alpha=0.95 -> runtime-tunable"
+else
+  echo "    SKIP: driver or graphene moments unavailable"
+fi
+
+[ "$fail" -eq 0 ] && { echo "PASS: alpha decoupled from moments, HBAR single-sourced, alpha runtime"; exit 0; }
+echo "FAIL: Phase-1 safety-factor invariants violated"; exit 1


### PR DESCRIPTION
## Summary
Phase 1 of the refactor (plan v2). **Refactor only — bit-identical at defaults.** Full suite
**13/13** green, including the new invariant guard. No moment math touched.

### New headers
- **`include/units.hpp`** — `chebyshev::HBAR = 0.6582119624 eV·fs`, the **sole home** for the
  time-evolution unit (was hard-coded ×5: 2× `chebyshev_moments.hpp` + the `_Device`/
  `_Graphene_NNN` forks + `chebyshev_solver.cpp`). Forks include it now; the duplicates vanish
  when the forks merge in Phase 6.
- **`include/recon_grid.hpp`** — `chebyshev::safety_factors()`: **two named, distinct** factors,
  not one α. `recon_cutoff` (α, default 0.95) = reconstruction-grid cutoff off the `1/√(1−x²)`
  edge; `bounds_pad` (default 0.10) = Gershgorin enclosure margin. Resolved once per process;
  **runtime-overridable** via `LSQUANT_RECON_ALPHA` / `LSQUANT_BOUNDS_PAD` (Phase 4 → run.json).

### Wiring (values unchanged → goldens bit-identical)
- 14 `*FromChebmom` grids → `safety_factors().recon_cutoff`; FFT edge → `1 − recon_cutoff`
- `chebyshev_solver.cpp`: `PAD` → `bounds_pad`; local `hbar` → `chebyshev::HBAR`
- removed the `KPM_ALPHA` const and the 5 `HBAR` copies

### Invariant + guard
`ScaleFactor()`/`ShiftFactor()` still use `chebyshev::CUTOFF = 1.00` **only** — α never enters
the moment rescale. New **`safety_factors_guard`** test enforces: (1) no α leak into the moment
factors, (2) the HBAR literal lives only in `units.hpp`, (3) `LSQUANT_RECON_ALPHA` widens the
reconstruction grid at runtime (graphene Kubo-Bastin range **7.14 @α=0.95 → 7.52 @α=1.0**).
Verified α=1.0 mode leaves `chain1d_analytic`/`chain1d_dos` green (moments are α-free).

## 🔒 Decision to ratify (do not auto-merge)
This touches the α/scale knobs — reserved for your review. The decision is to **ratify the
shipped default**: `recon_cutoff = 0.95` (reconstruction edge-safe), `bounds_pad = 0.10`,
moments at `CUTOFF = 1.00`. These reproduce every current golden bit-for-bit; α=1.0 is now a
runtime mode (legacy/edge-unsafe grid) rather than a recompile.

Doc note: `docs/spectral_scales.md` still says "KPM_ALPHA"; the rename to
`safety_factors().recon_cutoff` is left as a trivial follow-up (docs weren't in this phase's
whitelist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)