### PR TITLE
Refactor Phase 3: descriptor basis tags — manual tight-binding traceability

### DIFF
--- a/include/operator_descriptor.hpp
+++ b/include/operator_descriptor.hpp
@@ -23,9 +23,12 @@
 // The descriptor is the AUTHORITATIVE source of an operator's identity and of the spectral
 // window (a,b) used to rescale H into [-1,1]. It never enters the Chebyshev recursion.
 
+#include <vector>
+#include <complex>
+
 namespace lsquant
 {
-	constexpr int DESCRIPTOR_SCHEMA_VERSION = 1;
+	constexpr int DESCRIPTOR_SCHEMA_VERSION = 2;   // v2: optional basis block (Phase 3)
 
 	struct OperatorDescriptor
 	{
@@ -36,6 +39,18 @@ namespace lsquant
 		bool        has_bounds = false;   // (a,b) meaningful (Hamiltonian)
 		double      a = 0.0, b = 0.0;     // spectral_min, spectral_max
 		bool        valid = false;        // false if the file was absent / unparseable
+
+		// --- basis block (Phase 3, manual tight-binding traceability) -------------------
+		// Minimal orbital-tag basis for a spin-doubled TB model: each unit cell holds
+		// `orbitals_per_cell` orbitals whose spins are `orbital_spin` (+1 = up, -1 = down);
+		// the global index of (cell c, orbital o) is c*orbitals_per_cell + o. This makes the
+		// spin/orbital operators (SX/SY/SZ) DERIVABLE from the descriptor rather than opaque
+		// CSR blobs (the build_spin_operator gate below reproduces them). Kept IN the .desc
+		// (the Phase-3 "base in .desc" choice); a large H may move it to a shared sidecar later.
+		bool             has_basis = false;
+		int              orbitals_per_cell = 0;
+		std::vector<int> orbital_spin;    // size = orbitals_per_cell; +1/-1 per orbital
+		int              num_cells = 0;
 	};
 
 	// Parse a .desc file. Returns a descriptor with valid=false if the path cannot be opened.
@@ -43,6 +58,14 @@ namespace lsquant
 
 	// Convenience: if `desc_path` exists and carries bounds, fill (a,b) and return true.
 	bool descriptor_bounds(const std::string& desc_path, double& a, double& b);
+
+	// Build a Pauli spin operator (component 'X'|'Y'|'Z') over the descriptor's spin-doubled
+	// basis, as COO triplets. Within each cell the up/down orbital pair carries the standard
+	// Pauli matrix: sigma_x=[[0,1],[1,0]], sigma_y=[[0,-i],[i,0]], sigma_z=[[1,0],[0,-1]].
+	// Returns false if the descriptor has no usable spin-doubled basis.
+	bool build_spin_operator(const OperatorDescriptor& d, char component,
+	                         std::vector<int>& rows, std::vector<int>& cols,
+	                         std::vector<std::complex<double> >& vals);
 }
 
 #endif // LSQUANT_OPERATOR_DESCRIPTOR

--- a/src/operator_descriptor.cpp
+++ b/src/operator_descriptor.cpp
@@ -1,6 +1,7 @@
 #include "operator_descriptor.hpp"
 
 #include <fstream>
+#include <sstream>
 #include <string>
 
 namespace
@@ -38,6 +39,16 @@ namespace lsquant
 			else if (key == "provenance")   d.provenance  = val;
 			else if (key == "spectral_min") { d.a = std::stod(val); d.has_bounds = true; }
 			else if (key == "spectral_max") { d.b = std::stod(val); d.has_bounds = true; }
+			else if (key == "basis_orbitals_per_cell") { d.orbitals_per_cell = std::stoi(val); d.has_basis = true; }
+			else if (key == "basis_num_cells")         { d.num_cells = std::stoi(val);         d.has_basis = true; }
+			else if (key == "basis_orbital_spin")
+			{
+				// space-separated +/- (or +1/-1) signs, one per orbital in a cell
+				std::istringstream ss(val); std::string tok;
+				d.orbital_spin.clear();
+				while (ss >> tok) d.orbital_spin.push_back((!tok.empty() && tok[0] == '-') ? -1 : +1);
+				d.has_basis = true;
+			}
 			// unknown keys are ignored (forward-compatible with later schema versions)
 		}
 		d.valid = true;
@@ -49,5 +60,48 @@ namespace lsquant
 		const OperatorDescriptor d = read_descriptor(desc_path);
 		if (d.valid && d.has_bounds) { a = d.a; b = d.b; return true; }
 		return false;
+	}
+
+	bool build_spin_operator(const OperatorDescriptor& d, char component,
+	                         std::vector<int>& rows, std::vector<int>& cols,
+	                         std::vector<std::complex<double> >& vals)
+	{
+		typedef std::complex<double> cd;
+		rows.clear(); cols.clear(); vals.clear();
+		if (!d.has_basis || d.orbitals_per_cell <= 0 || d.num_cells <= 0) return false;
+		if ((int)d.orbital_spin.size() != d.orbitals_per_cell) return false;
+
+		// Identify the up (+1) and down (-1) orbital within a cell (spin-1/2 doubling).
+		int up = -1, dn = -1;
+		for (int o = 0; o < d.orbitals_per_cell; ++o)
+		{
+			if (d.orbital_spin[o] > 0 && up < 0) up = o;
+			if (d.orbital_spin[o] < 0 && dn < 0) dn = o;
+		}
+		if (up < 0 || dn < 0) return false;   // need one up and one down orbital
+
+		const int opc = d.orbitals_per_cell;
+		for (int c = 0; c < d.num_cells; ++c)
+		{
+			const int iu = c * opc + up;   // global index of the up orbital
+			const int id = c * opc + dn;   // global index of the down orbital
+			switch (component)
+			{
+				case 'X': case 'x':   // sigma_x = [[0,1],[1,0]]
+					rows.push_back(iu); cols.push_back(id); vals.push_back(cd(1, 0));
+					rows.push_back(id); cols.push_back(iu); vals.push_back(cd(1, 0));
+					break;
+				case 'Y': case 'y':   // sigma_y = [[0,-i],[i,0]]
+					rows.push_back(iu); cols.push_back(id); vals.push_back(cd(0, -1));
+					rows.push_back(id); cols.push_back(iu); vals.push_back(cd(0, +1));
+					break;
+				case 'Z': case 'z':   // sigma_z = [[1,0],[0,-1]]
+					rows.push_back(iu); cols.push_back(iu); vals.push_back(cd(+1, 0));
+					rows.push_back(id); cols.push_back(id); vals.push_back(cd(-1, 0));
+					break;
+				default: return false;
+			}
+		}
+		return true;
 	}
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -171,3 +171,16 @@ add_test(NAME descriptor_conformance
 # committed chain1d.HAM.desc (Lanczos [-2,2]) and the DOS must match 1/(pi sqrt(4-E^2)).
 add_test(NAME descriptor_bounds
          COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/descriptor_bounds.sh ${CMAKE_BINARY_DIR})
+
+# --- manual tight-binding traceability via descriptor basis tags (Phase 3) ------
+# Builds SX/SY/SZ from the basis tags in chain1d_mag.HAM.desc and asserts they reproduce the
+# committed CSRs exactly -- the conformance gate for the manual-TB descriptor path.
+add_executable(tb_descriptor_test tb_descriptor_test.cpp
+               ${CMAKE_SOURCE_DIR}/src/operator_descriptor.cpp)
+target_include_directories(tb_descriptor_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME tb_descriptor
+         COMMAND tb_descriptor_test
+                 ${SPINOPS_DIR}/chain1d_mag.HAM.desc
+                 ${SPINOPS_DIR}/chain1d_mag.SX.CSR
+                 ${SPINOPS_DIR}/chain1d_mag.SY.CSR
+                 ${SPINOPS_DIR}/chain1d_mag.SZ.CSR)

--- a/test/models/chain1d_mag/operators/chain1d_mag.HAM.desc
+++ b/test/models/chain1d_mag/operators/chain1d_mag.HAM.desc
@@ -1,0 +1,9 @@
+observable: hamiltonian
+component: 
+units: eV
+provenance: manual tight-binding (magnetic chain -J_ex sigma_z); basis tags hand-authored
+spectral_min: -2.0998975970126095
+spectral_max: 2.0999553084687053
+basis_orbitals_per_cell: 2
+basis_orbital_spin: + -
+basis_num_cells: 64

--- a/test/tb_descriptor_test.cpp
+++ b/test/tb_descriptor_test.cpp
@@ -1,0 +1,79 @@
+// Phase 3 -- manual tight-binding traceability via descriptor basis tags.
+//
+// The magnetic-chain spin operators SX/SY/SZ are no longer opaque CSR blobs: they are
+// DERIVABLE from the basis tags in chain1d_mag.HAM.desc (orbitals_per_cell / orbital_spin /
+// num_cells). This test builds each operator from those tags (build_spin_operator) and asserts
+// it reproduces the committed CSR EXACTLY -- the conformance gate for the manual-TB path.
+// (spin_algebra, which reads the committed CSRs, remains the algebraic check; together they
+// show the operators are both correct AND reconstructible from their description.)
+//
+// Usage: tb_descriptor_test <chain1d_mag.HAM.desc> <SX.CSR> <SY.CSR> <SZ.CSR>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <complex>
+#include <map>
+#include <string>
+#include "operator_descriptor.hpp"
+
+typedef std::complex<double> cd;
+typedef std::map<std::pair<int,int>, cd> SpMap;
+
+// Parse the project CSR format: "dim nnz" / nnz (re im) / nnz columns / (dim+1) rowIndex.
+static bool read_csr(const std::string& path, int& dim, SpMap& M) {
+    std::ifstream f(path.c_str());
+    if (!f) return false;
+    int nnz; f >> dim >> nnz;
+    std::vector<cd> vals(nnz); std::vector<int> cols(nnz), rowp(dim+1);
+    for (int i=0;i<nnz;i++){ double re,im; f>>re>>im; vals[i]=cd(re,im); }
+    for (int i=0;i<nnz;i++) f>>cols[i];
+    for (int i=0;i<dim+1;i++) f>>rowp[i];
+    M.clear();
+    for (int r=0;r<dim;r++) for (int k=rowp[r]; k<rowp[r+1]; ++k)
+        if (vals[k] != cd(0,0)) M[{r,cols[k]}] = vals[k];
+    return true;
+}
+
+static int g_fail = 0;
+static void compare(const std::string& tag, const SpMap& built, const SpMap& golden) {
+    // every nonzero must match (both directions), to machine precision
+    double maxdiff = 0.0; int extra = 0, missing = 0;
+    for (const auto& kv : built) {
+        auto it = golden.find(kv.first);
+        if (it == golden.end()) { extra++; continue; }
+        maxdiff = std::max(maxdiff, std::abs(kv.second - it->second));
+    }
+    for (const auto& kv : golden) if (built.find(kv.first) == built.end()) missing++;
+    bool ok = (extra==0 && missing==0 && maxdiff < 1e-12 && built.size()==golden.size());
+    std::cout << (ok?"  OK   ":"  FAIL ") << tag
+              << ": built nnz=" << built.size() << " golden nnz=" << golden.size()
+              << " maxdiff=" << maxdiff << " extra=" << extra << " missing=" << missing << "\n";
+    if (!ok) g_fail = 1;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 5) { std::cerr << "usage: " << argv[0] << " <HAM.desc> <SX.CSR> <SY.CSR> <SZ.CSR>\n"; return 2; }
+    lsquant::OperatorDescriptor d = lsquant::read_descriptor(argv[1]);
+    if (!d.valid || !d.has_basis) { std::cerr << "FAIL: descriptor has no basis block\n"; return 1; }
+    std::cout << "basis: orbitals_per_cell=" << d.orbitals_per_cell
+              << " num_cells=" << d.num_cells << " spins=";
+    for (int s : d.orbital_spin) std::cout << (s>0?'+':'-');
+    std::cout << "\n";
+
+    const char comps[3] = {'X','Y','Z'};
+    for (int i=0;i<3;i++) {
+        std::vector<int> r,c; std::vector<cd> v;
+        if (!lsquant::build_spin_operator(d, comps[i], r, c, v)) {
+            std::cerr << "FAIL: build_spin_operator(" << comps[i] << ") returned false\n"; return 1;
+        }
+        SpMap built; for (size_t k=0;k<r.size();++k) if (v[k]!=cd(0,0)) built[{r[k],c[k]}] += v[k];
+        int dim; SpMap golden;
+        if (!read_csr(argv[2+i], dim, golden)) { std::cerr << "FAIL: cannot read " << argv[2+i] << "\n"; return 1; }
+        if (dim != d.orbitals_per_cell*d.num_cells)
+            { std::cout << "  FAIL S" << comps[i] << ": dim " << dim << " != basis dim\n"; g_fail=1; }
+        compare(std::string("S")+comps[i], built, golden);
+    }
+
+    if (g_fail==0) { std::cout << "PASS: SX/SY/SZ reproduced exactly from descriptor basis tags\n"; return 0; }
+    std::cerr << "FAIL: built spin operators differ from committed CSRs\n"; return 1;
+}


### PR DESCRIPTION
## Summary
Phase 3. The spin/orbital operators become **derivable from the descriptor** instead of opaque
CSR blobs. **Purely additive — no numerical change, all goldens bit-identical. ctest 16/16.**

### What landed
- **`operator_descriptor` schema v2** — optional basis block: `basis_orbitals_per_cell`,
  `basis_orbital_spin` (`+`/`-` per orbital), `basis_num_cells`.
- **`build_spin_operator(desc, 'X'|'Y'|'Z')`** — constructs the standard Pauli operator over the
  spin-doubled basis (`σx=[[0,1],[1,0]]`, `σy=[[0,-i],[i,0]]`, `σz=[[1,0],[0,-1]]`,
  block-diagonal over cells) — the exact convention of the committed w2s CSRs.
- **`chain1d_mag.HAM.desc`** — w2s-produced HAM descriptor (Lanczos bounds ±2.0999) augmented
  with the hand-authored basis block.

### Test — `tb_descriptor`
Builds SX/SY/SZ from the descriptor tags and asserts they reproduce the committed
`chain1d_mag` CSRs **exactly** (nnz 128=128, maxdiff **0**, no extra/missing). This is the
conformance gate for the manual-TB path; `spin_algebra` still guards the su(2) algebra.

## 🔒 Decision taken (reversible) — base location
Per "duplicate first", the basis lives **in the `.desc`** (not a separate `.basis` sidecar).
For a large H this duplicates the basis across operators; the schema is structured so it can be
hoisted into a shared sidecar later without touching `build_spin_operator`. Reserved for your
ratification like Phases 1–2.

Note: producer-side parity (w2s emitting the same basis tags via `hopping_list` /
`exact_spin_operator`) is the coordinated follow-up in the w2s repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)