### PR TITLE
Refactor Phase 4: JSON run-config + lsquant inspect (+ CorrOp state-file fix)

### DIFF
--- a/include/run_config.hpp
+++ b/include/run_config.hpp
@@ -1,0 +1,52 @@
+#ifndef LSQUANT_RUN_CONFIG
+#define LSQUANT_RUN_CONFIG
+
+#include <string>
+#include <map>
+
+// A run is described by a small, human-readable JSON object instead of positional argv and
+// filename-encoded metadata. Example run.json (flat object, the v1 schema):
+//
+//   {
+//     "label":          "graphene_golden",
+//     "operator_left":  "VX",
+//     "operator_right": "VX",
+//     "num_moments":    64,
+//     "kernel":         "jackson",
+//     "lambda":         0.0,
+//     "state":          "default",
+//     "alpha":          0.95,
+//     "output":         "NonEqOpVX-VXgraphene_goldenKPM_M64x64_statedefault.chebmom2D"
+//   }
+//
+// The parser is a tiny, dependency-FREE flat-JSON reader (string/number/bool values, no nested
+// objects or arrays). This keeps lsquant offline-safe -- no fetched JSON library -- consistent
+// with the w2s decoupling; a full JSON lib can replace parse_flat_json later without touching
+// callers. Numerical knobs (alpha, bounds) still resolve through their existing homes
+// (recon_grid.hpp / .desc); run.json just records the intent, and `lsquant inspect` reports it.
+
+namespace lsquant
+{
+	// Parse a flat JSON object into raw (unquoted) string values keyed by name.
+	// Returns empty map if the file is missing or has no '{'.
+	std::map<std::string, std::string> parse_flat_json(const std::string& path);
+
+	struct RunConfig
+	{
+		std::string label;
+		std::string operator_left;     // OPL
+		std::string operator_right;    // OPR
+		int         num_moments = 0;
+		std::string kernel = "jackson";
+		double      lambda  = 0.0;
+		std::string state   = "default";
+		double      alpha   = -1.0;    // <0 means "unset -> use the recon_grid default/env"
+		std::string output;            // declared output name (optional)
+		bool        valid   = false;
+		std::string error;
+	};
+
+	RunConfig read_run_config(const std::string& path);
+}
+
+#endif // LSQUANT_RUN_CONFIG

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(KPM_LIB_SOURCES
     chebyshev_momentsLocal.cpp
     sparse_matrix.cpp
     operator_descriptor.cpp
+    run_config.cpp
     special_functions.cpp
     Kubo_solver_FFT.cpp
     Kubo_solver_FFT_postProcess.cpp
@@ -94,6 +95,7 @@ set(LINQT_APPS
     "device-postProcess_Graphene_NNN|device-postProcess_Graphene_NNN.cpp"
     "inline_compute-Kubo-kpm-FFT-nonOrth|inline_compute-Kubo-kpm-FFT-nonOrth.cpp"
     "inline_compute-kpm-TimeEvOpwithWF|inline_compute-kpm-TimeEvOpwithWF.cpp"
+    "lsquant_inspect|lsquant_inspect.cpp"
 )
 
 foreach(entry IN LISTS LINQT_APPS)

--- a/src/inline_compute-kpm-CorrOp.cpp
+++ b/src/inline_compute-kpm-CorrOp.cpp
@@ -41,10 +41,6 @@ int main(int argc, char *argv[])
 	const int numMoms = atoi(S_NMOM.c_str() );
 	const int numTimes= atoi(S_NTIME.c_str() );
 	const double tmax = stod( S_TMAX );
-	int numStates = 1;
-
-	if (argc ==8 )
-		numStates = atoi( argv[7] );
 
 	chebyshev::MomentsTD chebMoms(numMoms, numTimes); //load number of moments
 
@@ -64,8 +60,8 @@ int main(int argc, char *argv[])
 		builder.BuildOPFromCSRFile(input);
 	
 		if( i == 0 ) //is hamiltonian
-		//Obtain automatically the energy bounds
-		 spectral_bounds = chebyshev::utility::SpectralBounds(OP[0]);
+		//Bounds from the descriptor if present (Phase 2), else BOUNDS file / Gershgorin
+		 spectral_bounds = chebyshev::utility::SpectralBounds(OP[0], "operators/" + LABEL + ".HAM.desc");
 	};
 	//CONFIGURE THE CHEBYSHEV MOMENTS
 	chebMoms.SystemLabel(LABEL);
@@ -75,10 +71,14 @@ int main(int argc, char *argv[])
 	chebMoms.SetAndRescaleHamiltonian(OP[0]);
 	chebMoms.Print();
 
-	//Compute the chebyshev expansion table
+	//Compute the chebyshev expansion table.
+	// Bug fix (Phase 4): the optional 7th argument is a STATE FILE (as in the MSD/nonEqOp
+	// drivers), loaded via LoadStateFile -- e.g. an exact-trace 'local'/'exact' spec. The old
+	// code did `numStates = atoi(argv[7])` (so "exact" -> 0) and never loaded the file (a dead
+	// `argc==5` branch), silently forcing the default single random vector.
 	qstates::generator gen;
-	if( argc == 5)
-		gen  = qstates::LoadStateFile(argv[5]);
+	if( argc == 8 )
+		gen  = qstates::LoadStateFile(argv[7]);
 
 	chebyshev::TimeDependentCorrelations( OP[1], OP[2], chebMoms, gen);
 

--- a/src/inline_compute-kpm-nonEqOp.cpp
+++ b/src/inline_compute-kpm-nonEqOp.cpp
@@ -11,6 +11,7 @@
 #include "sparse_matrix.hpp"
 #include "quantum_states.hpp"
 #include "chebyshev_solver.hpp"
+#include "run_config.hpp"
 
 namespace kpmKubo
 {
@@ -22,22 +23,34 @@ void printWelcomeMessage();
 }
 int main(int argc, char *argv[])
 {
-	if ( !(argc == 5 || argc == 6) )
+	// Two input paths, same computation:
+	//   lsquant ... --config run.json          (Phase 4: JSON config)
+	//   LABEL OPR OPL numMom [state]           (legacy positional argv -- fallback)
+	std::string LABEL, S_OPR, S_OPL, S_NUM_MOM, state_file;
+	bool have_state = false;
+
+	if ( argc == 3 && std::string(argv[1]) == "--config" )
+	{
+		const lsquant::RunConfig c = lsquant::read_run_config(argv[2]);
+		if ( !c.valid ) { std::cerr << "config error: " << c.error << std::endl; return 1; }
+		kpmKubo::printWelcomeMessage();
+		LABEL = c.label; S_OPR = c.operator_right; S_OPL = c.operator_left;
+		S_NUM_MOM = std::to_string(c.num_moments);
+		if ( c.state != "default" && !c.state.empty() ) { state_file = c.state; have_state = true; }
+	}
+	else if ( argc == 5 || argc == 6 )
+	{
+		kpmKubo::printWelcomeMessage();
+		LABEL = argv[1]; S_OPR = argv[2]; S_OPL = argv[3]; S_NUM_MOM = argv[4];
+		if ( argc == 6 ) { state_file = argv[5]; have_state = true; }
+	}
+	else
 	{
 		kpmKubo::printHelpMessage();
 		return 0;
 	}
-	else
-		kpmKubo::printWelcomeMessage();
-	
-	const std::string
-		LABEL = argv[1],
-		S_OPR = argv[2],
-		S_OPL = argv[3],
-		S_NUM_MOM = argv[4];
 
-
-	const int numMoms= atoi(argv[4]);
+	const int numMoms= atoi(S_NUM_MOM.c_str());
 	chebyshev::Moments2D chebMoms(numMoms,numMoms); //load number of moments
 
 	SparseMatrixType OP[3];
@@ -71,9 +84,9 @@ int main(int argc, char *argv[])
 
 	//Compute the chebyshev expansion table
 	qstates::generator gen;
-	if( argc == 6)	
-		gen  = qstates::LoadStateFile(argv[5]);
-	
+	if( have_state )
+		gen  = qstates::LoadStateFile(state_file);
+
 	chebyshev::CorrelationExpansionMoments( OP[1], OP[2], chebMoms, gen );
 
 	//Save the table in a file

--- a/src/lsquant_inspect.cpp
+++ b/src/lsquant_inspect.cpp
@@ -1,0 +1,72 @@
+// lsquant inspect -- print what a run.json (and an operator .desc) will actually do, including
+// the resolved NUMERICAL PROVENANCE (alpha, bounds source, hbar/units, kernel). Replaces having
+// to read positional argv and decode filename metadata to understand a run.
+//
+// Usage:
+//   lsquant_inspect <run.json>            inspect a run config
+//   lsquant_inspect <operator.desc>       inspect an operator descriptor
+#include <iostream>
+#include <fstream>
+#include <string>
+#include "run_config.hpp"
+#include "operator_descriptor.hpp"
+#include "units.hpp"
+#include "recon_grid.hpp"
+
+static bool ends_with(const std::string& s, const std::string& suf) {
+    return s.size() >= suf.size() && s.compare(s.size()-suf.size(), suf.size(), suf) == 0;
+}
+static bool file_exists(const std::string& p) { std::ifstream f(p.c_str()); return f.good(); }
+
+static void inspect_desc(const std::string& path) {
+    lsquant::OperatorDescriptor d = lsquant::read_descriptor(path);
+    std::cout << "operator descriptor: " << path << "\n";
+    if (!d.valid) { std::cout << "  (could not parse)\n"; return; }
+    std::cout << "  observable : " << d.observable << "\n"
+              << "  component  : " << (d.component.empty() ? "(none)" : d.component) << "\n"
+              << "  units      : " << d.units << "\n"
+              << "  provenance : " << d.provenance << "\n";
+    if (d.has_bounds) std::cout << "  bounds(a,b): [" << d.a << ", " << d.b << "]\n";
+    if (d.has_basis)  { std::cout << "  basis      : " << d.orbitals_per_cell << " orbitals/cell x "
+                                  << d.num_cells << " cells, spins "; for (int s:d.orbital_spin) std::cout<<(s>0?'+':'-'); std::cout<<"\n"; }
+}
+
+static void inspect_run(const std::string& path) {
+    lsquant::RunConfig c = lsquant::read_run_config(path);
+    std::cout << "run config: " << path << "\n";
+    if (!c.valid) { std::cout << "  INVALID: " << c.error << "\n"; return; }
+
+    const std::string ham_desc = "operators/" + c.label + ".HAM.desc";
+    const std::string bounds_src =
+        file_exists("BOUNDS")  ? "BOUNDS file (explicit override)" :
+        file_exists(ham_desc)  ? ("descriptor " + ham_desc + " (producer Lanczos)") :
+                                 "Gershgorin enclosure + pad (fallback)";
+    // alpha: run.json value if set, else the recon_grid default/env
+    const double alpha = (c.alpha >= 0.0) ? c.alpha : chebyshev::safety_factors().recon_cutoff;
+
+    std::cout << "  what runs   : <" << c.operator_left << "|.|" << c.operator_right
+              << "> correlation on '" << c.label << "', M = " << c.num_moments << "\n"
+              << "  state       : " << c.state << "\n"
+              << "  kernel      : " << c.kernel;
+    if (c.kernel == "lorentz") std::cout << " (lambda = " << c.lambda << ")";
+    std::cout << "\n";
+    std::cout << "  -- numerical provenance --\n"
+              << "  recon alpha : " << alpha << (c.alpha>=0.0 ? " (from run.json)" : " (recon_grid default/env)") << "\n"
+              << "  bounds pad  : " << chebyshev::safety_factors().bounds_pad << "\n"
+              << "  bounds from : " << bounds_src << "\n"
+              << "  hbar (units): " << chebyshev::HBAR << " eV*fs\n";
+    if (file_exists(ham_desc)) { std::cout << "  -- Hamiltonian descriptor --\n"; inspect_desc(ham_desc); }
+    std::cout << "  output      : "
+              << (c.output.empty() ? "(derived from run parameters)" : c.output) << "\n";
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: " << argv[0] << " <run.json | operator.desc>\n";
+        return 2;
+    }
+    const std::string path = argv[1];
+    if (ends_with(path, ".desc")) inspect_desc(path);
+    else                          inspect_run(path);
+    return 0;
+}

--- a/src/run_config.cpp
+++ b/src/run_config.cpp
@@ -1,0 +1,89 @@
+#include "run_config.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <cctype>
+
+namespace
+{
+	// Minimal flat-JSON object reader: extracts top-level "key": value pairs.
+	// Values may be quoted strings, numbers, or true/false/null. Nested objects/arrays are
+	// NOT supported (the v1 run.json schema is flat). Tolerant of whitespace and trailing commas.
+	std::map<std::string, std::string> parse(const std::string& text)
+	{
+		std::map<std::string, std::string> kv;
+		size_t i = text.find('{');
+		if (i == std::string::npos) return kv;
+		++i;
+		const size_t n = text.size();
+		auto skipws = [&] { while (i < n && std::isspace((unsigned char)text[i])) ++i; };
+
+		while (i < n)
+		{
+			skipws();
+			if (i >= n || text[i] == '}') break;
+			if (text[i] == ',') { ++i; continue; }
+			if (text[i] != '"') { ++i; continue; }      // expect a quoted key
+			// --- key ---
+			++i; std::string key;
+			while (i < n && text[i] != '"') { if (text[i]=='\\' && i+1<n) ++i; key += text[i++]; }
+			if (i < n) ++i;                              // closing quote
+			skipws();
+			if (i < n && text[i] == ':') ++i;
+			skipws();
+			// --- value ---
+			std::string val;
+			if (i < n && text[i] == '"')
+			{
+				++i;
+				while (i < n && text[i] != '"') { if (text[i]=='\\' && i+1<n) ++i; val += text[i++]; }
+				if (i < n) ++i;
+			}
+			else
+			{
+				while (i < n && text[i] != ',' && text[i] != '}' && !std::isspace((unsigned char)text[i]))
+					val += text[i++];
+			}
+			if (!key.empty()) kv[key] = val;
+		}
+		return kv;
+	}
+}
+
+namespace lsquant
+{
+	std::map<std::string, std::string> parse_flat_json(const std::string& path)
+	{
+		std::ifstream f(path.c_str());
+		if (!f.is_open()) return {};
+		std::stringstream ss; ss << f.rdbuf();
+		return parse(ss.str());
+	}
+
+	RunConfig read_run_config(const std::string& path)
+	{
+		RunConfig c;
+		auto kv = parse_flat_json(path);
+		if (kv.empty()) { c.error = "cannot open or parse " + path; return c; }
+
+		auto get = [&](const char* k, const std::string& dflt) -> std::string {
+			auto it = kv.find(k); return it == kv.end() ? dflt : it->second;
+		};
+		c.label          = get("label", "");
+		c.operator_left  = get("operator_left", "");
+		c.operator_right = get("operator_right", "");
+		c.kernel         = get("kernel", "jackson");
+		c.state          = get("state", "default");
+		c.output         = get("output", "");
+		try {
+			if (kv.count("num_moments")) c.num_moments = std::stoi(kv["num_moments"]);
+			if (kv.count("lambda"))      c.lambda      = std::stod(kv["lambda"]);
+			if (kv.count("alpha"))       c.alpha       = std::stod(kv["alpha"]);
+		} catch (...) { c.error = "non-numeric value for num_moments/lambda/alpha"; return c; }
+
+		if (c.label.empty())       { c.error = "missing 'label'"; return c; }
+		if (c.num_moments <= 0)    { c.error = "missing/invalid 'num_moments'"; return c; }
+		c.valid = true;
+		return c;
+	}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -184,3 +184,16 @@ add_test(NAME tb_descriptor
                  ${SPINOPS_DIR}/chain1d_mag.SX.CSR
                  ${SPINOPS_DIR}/chain1d_mag.SY.CSR
                  ${SPINOPS_DIR}/chain1d_mag.SZ.CSR)
+
+# --- JSON run-config equivalence + inspect (Phase 4) ----------------------------
+# A run.json reproduces the argv path byte-for-byte (same computation, new description), and
+# `lsquant inspect` reports the run + resolved numerical provenance (alpha, bounds source, hbar).
+add_test(NAME config_equivalence
+         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/config_equivalence.sh ${CMAKE_BINARY_DIR})
+
+# --- CorrOp state-file regression (Phase 4 bug fix) -----------------------------
+# Pins the fix to the atoi(argv[7]) bug: the VAC driver now loads its 7th arg as a state file
+# (was misparsed as a vector count, so "exact" -> 0 -> default). Asserts the exact-trace spec
+# is honored (output tagged stateexact) and deterministic.
+add_test(NAME corrop_state_honored
+         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/corrop_state_honored.sh ${CMAKE_BINARY_DIR})

--- a/test/config_equivalence.sh
+++ b/test/config_equivalence.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Phase 4 -- JSON run-config equivalence + inspect.
+#
+# (1) A run.json drives inline_compute-kpm-nonEqOp to produce moments BYTE-IDENTICAL to the
+#     legacy positional-argv invocation (same KPM_SEED) -- the config path changes how a run is
+#     described, not what it computes.
+# (2) `lsquant inspect run.json` prints the run and its resolved numerical provenance
+#     (recon alpha, bounds source, hbar/units) -- greppable, no need to decode argv/filenames.
+#
+# Usage: config_equivalence.sh <BUILD_DIR>
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$(cd "${1:-$REPO/build}" && pwd)"
+DRV="$BUILD/inline_compute-kpm-nonEqOp"
+INSPECT="$BUILD/lsquant_inspect"
+OPD="$REPO/test/golden/operators"
+
+[ -x "$DRV" ]     || { echo "FAIL: nonEqOp driver missing"; exit 1; }
+[ -x "$INSPECT" ] || { echo "FAIL: lsquant_inspect missing"; exit 1; }
+[ -f "$OPD/graphene_golden.HAM.CSR" ] || { echo "FAIL: graphene operators missing"; exit 1; }
+
+export KPM_SEED=12345
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/operators"
+cp "$OPD/graphene_golden.HAM.CSR" "$OPD/graphene_golden.VX.CSR" "$T/operators/"
+cp "$OPD/graphene_golden.HAM.desc" "$T/operators/" 2>/dev/null || true   # for the inspect bounds line
+cat > "$T/run.json" <<'JSON'
+{
+  "label":          "graphene_golden",
+  "operator_left":  "VX",
+  "operator_right": "VX",
+  "num_moments":    64,
+  "kernel":         "jackson",
+  "state":          "default"
+}
+JSON
+
+( cd "$T"
+  # (1) equivalence: argv vs --config, byte-identical
+  "$DRV" graphene_golden VX VX 64 >/dev/null 2>&1
+  mv NonEqOpVX-VXgraphene_golden*.chebmom2D argv.chebmom2D
+  "$DRV" --config run.json >/dev/null 2>&1
+  mv NonEqOpVX-VXgraphene_golden*.chebmom2D config.chebmom2D
+  if diff -q argv.chebmom2D config.chebmom2D >/dev/null; then
+      echo "PASS(equivalence): run.json moments are byte-identical to the argv path"
+  else
+      echo "FAIL(equivalence): run.json moments differ from the argv path"; exit 1
+  fi
+
+  # (2) inspect prints the run + numerical provenance
+  rep="$("$INSPECT" run.json)"
+  echo "$rep" | sed 's/^/    /'
+  echo "$rep" | grep -q "graphene_golden"                  || { echo "FAIL(inspect): label missing"; exit 1; }
+  echo "$rep" | grep -q "M = 64"                           || { echo "FAIL(inspect): M missing"; exit 1; }
+  echo "$rep" | grep -qiE "recon alpha"                    || { echo "FAIL(inspect): alpha missing"; exit 1; }
+  echo "$rep" | grep -qiE "hbar"                           || { echo "FAIL(inspect): hbar missing"; exit 1; }
+  echo "$rep" | grep -qiE "bounds from"                    || { echo "FAIL(inspect): bounds source missing"; exit 1; }
+  echo "PASS(inspect): report includes run parameters and numerical provenance"
+)
+echo "PASS: JSON config is equivalent to argv and inspect reports provenance"

--- a/test/corrop_state_honored.sh
+++ b/test/corrop_state_honored.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Phase 4 -- regression for the CorrOp state-file bug.
+#
+# inline_compute-kpm-CorrOp used to do `numStates = atoi(argv[7])` and never load the state
+# file (a dead argc==5 branch), so passing "exact" silently became 0 and the run fell back to a
+# single default random vector -- which is why a deterministic VAC<->MSD golden was impossible.
+# The fix loads argv[7] as a STATE FILE (like the MSD/nonEqOp drivers). This asserts the exact-
+# trace state spec is honored: the output is tagged ...stateexact... (the bug tagged it
+# ...statedefault...) and is byte-reproducible across two runs (exact trace is deterministic).
+#
+# Usage: corrop_state_honored.sh <BUILD_DIR>
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$(cd "${1:-$REPO/build}" && pwd)"
+DRV="$BUILD/inline_compute-kpm-CorrOp"
+OPD="$REPO/test/golden/chain1d_ballistic/operators"
+
+[ -x "$DRV" ] || { echo "FAIL: CorrOp driver missing"; exit 1; }
+[ -f "$OPD/chain1d.HAM.CSR" ] && [ -f "$OPD/chain1d.VX.CSR" ] || { echo "FAIL: chain operators missing"; exit 1; }
+
+N=$(head -1 "$OPD/chain1d.HAM.CSR" | awk '{print $1}')
+run() {  # runs CorrOp in a fresh tmp dir; echoes ONLY that dir
+    local T; T="$(mktemp -d)"; mkdir -p "$T/operators"
+    cp "$OPD/chain1d.HAM.CSR" "$OPD/chain1d.VX.CSR" "$T/operators/"
+    cp "$OPD/chain1d.HAM.desc" "$T/operators/" 2>/dev/null || true
+    ( cd "$T"
+      { echo local; echo "$N"; seq 0 $((N-1)); } > exact
+      "$DRV" chain1d VX VX 32 16 10 exact >/dev/null 2>&1 )
+    echo "$T"
+}
+T1="$(run)"; f1="$(cd "$T1" && ls TimeCorr*chebmomTD)"
+T2="$(run)"; f2="$(cd "$T2" && ls TimeCorr*chebmomTD)"
+trap 'rm -rf "$T1" "$T2"' EXIT
+
+echo "produced: $f1"
+case "$f1" in
+  *stateexact*) echo "PASS(honored): exact-trace state file is loaded (output tagged stateexact)";;
+  *statedefault*) echo "FAIL: state file ignored -- output is statedefault (atoi bug regressed)"; exit 1;;
+  *) echo "FAIL: unexpected output name '$f1'"; exit 1;;
+esac
+
+if diff -q "$T1/$f1" "$T2/$f2" >/dev/null; then
+    echo "PASS(deterministic): exact-trace VAC moments are byte-identical across runs"
+else
+    echo "FAIL: exact-trace VAC moments not reproducible"; exit 1
+fi
+echo "PASS: CorrOp honors the state file (atoi bug fixed)"


### PR DESCRIPTION
## Summary
Phase 4 (no 🔒). Replaces positional argv / filename metadata with a readable `run.json`, plus an
`inspect` tool that prints a run's resolved numerical provenance. **No computation changes — all
goldens bit-identical. ctest 18/18.**

### What landed
- **`include/run_config.hpp` + `src/run_config.cpp`** — `RunConfig` + a tiny **dependency-free**
  flat-JSON reader (string/number/bool; no nesting). Keeps lsquant offline-safe (no fetched JSON
  lib), same philosophy as the w2s decoupling; a full lib can drop in later.
- **`lsquant_inspect`** (new target) — prints what a `run.json` (or `.desc`) does, including the
  greppable **numerical provenance**: resolved recon α, bounds source (BOUNDS file / descriptor /
  Gershgorin), ℏ/units, kernel/λ.
- **`inline_compute-kpm-nonEqOp --config run.json`** — argv preserved as fallback; config path is
  **byte-identical** to argv.
- **CorrOp state-file bug fixed** — the 7th arg is now a state file (`LoadStateFile`), was
  `numStates = atoi(argv[7])` (so `"exact"` → 0 → silent default single random vector). Bounds also
  routed through the descriptor (Phase 2).

### Tests
- **`config_equivalence`** — `run.json` moments == argv byte-for-byte; `inspect` reports
  label/M/α/bounds-source/ℏ (and "bounds from descriptor" when a `.desc` is present).
- **`corrop_state_honored`** — exact-trace state spec honored (output tagged `stateexact`) and
  byte-reproducible; pins the `atoi` fix.

No 🔒 decision in this phase; merging per the standing rule (green, additive, bit-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)