### PR TITLE
Refactor Phase 5 (slice 1): unify the Kubo reconstruction — formula as data

### DIFF
--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -1,0 +1,40 @@
+#ifndef LSQUANT_OBSERVABLE
+#define LSQUANT_OBSERVABLE
+
+#include <vector>
+#include <utility>
+#include <complex>
+#include "chebyshev_moments.hpp"
+
+// Phase 5 -- "a formula is a piece of data, not an executable."
+//
+// The Kubo-Greenwood and Kubo-Bastin reconstructions share one inner double-Chebyshev sum;
+// they differ ONLY in four data fields. Greenwood is the degenerate (Fermi-surface-only) case
+// of Bastin: same sum, half the prefactor, no Fermi-sea integral, coarser grid. Capturing those
+// four fields as a KuboObservable collapses the duplicated *FromChebmom drivers into one
+// reconstruction routine; each driver becomes a thin wrapper that picks the observable and
+// writes the file.
+
+namespace lsquant
+{
+	struct KuboObservable
+	{
+		const char* name;
+		// Green's-function kernel on the n-index: greenR_chebF (Greenwood) or DgreenR_chebF (Bastin)
+		std::complex<double> (*green)(double, const double);
+		double prefactor;      // -1.0 (Greenwood, Fermi-surface) | -2.0 (Bastin, + Fermi-sea term)
+		int    num_div_mult;   // energy grid = num_div_mult * HighestMomentNumber : 1 | 30
+		bool   integrate;      // false (Greenwood) | true (Bastin: cumulative Fermi-sea integral)
+	};
+
+	extern const KuboObservable KUBO_GREENWOOD;
+	extern const KuboObservable KUBO_BASTIN;
+
+	// Reconstruct sigma(E) on the uniform [-alpha, alpha] grid (alpha = safety_factors().recon_cutoff)
+	// for the given observable. Returns (physical energy, value) pairs (num_div-1 of them, matching
+	// the legacy drivers). The moments must already be kernel-damped (ApplyJacksonKernel).
+	std::vector<std::pair<double,double> >
+	reconstruct_kubo(chebyshev::Moments2D& mu, const KuboObservable& obs);
+}
+
+#endif // LSQUANT_OBSERVABLE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(KPM_LIB_SOURCES
     sparse_matrix.cpp
     operator_descriptor.cpp
     run_config.cpp
+    reconstruction.cpp
     special_functions.cpp
     Kubo_solver_FFT.cpp
     Kubo_solver_FFT_postProcess.cpp

--- a/src/kuboBastinFromChebmom.cpp
+++ b/src/kuboBastinFromChebmom.cpp
@@ -5,97 +5,52 @@
 #include <fstream>		/* for std::ofstream and std::ifstream functions classes*/
 #include <vector>		/* for std::vector mostly class*/
 #include <complex>		/* for std::vector mostly class*/
-#include <omp.h>
 
-#include "chebyshev_solver.hpp"
-#include "chebyshev_coefficients.hpp"
 #include "chebyshev_moments.hpp"
+#include "observable.hpp"
+
+// Thin wrapper (Phase 5): the Kubo-Bastin reconstruction now lives in the unified
+// lsquant::reconstruct_kubo (formula = data, see include/observable.hpp). This driver only
+// reads the moments, applies the kernel, picks the KUBO_BASTIN observable, and writes the file.
 
 void printHelpMessage();
 void printWelcomeMessage();
 
 int main(int argc, char *argv[])
-{	
-	if (argc != 3)
-	{
-		printHelpMessage();
-		return 0;
-	}
-	else
-		printWelcomeMessage();
+{
+	if (argc != 3) { printHelpMessage(); return 0; }
+	printWelcomeMessage();
 
-	const double broadening  = stod(argv[2]);
+	const double broadening = stod(argv[2]);
 
+	chebyshev::Moments2D mu(argv[1]);
+	mu.ApplyJacksonKernel(broadening, broadening);
 
-	//Read the chebyshev moments from the file
- 	chebyshev::Moments2D mu(argv[1]); 
-	//and apply the appropiated kernel
-	mu.ApplyJacksonKernel(broadening,broadening);
+	std::cout << "Computing the Kubo-Bastin reconstruction using "
+	          << mu.HighestMomentNumber(0) << " x " << mu.HighestMomentNumber(1) << " moments" << std::endl;
 
-	const int num_div = 30*mu.HighestMomentNumber();
-	
-	const double
-	xbound = chebyshev::safety_factors().recon_cutoff;
-		
-	std::vector< double >  energies(num_div,0);
-	for( int i=0; i < num_div; i++)
-		energies[i] = -xbound + i*(2*xbound)/(num_div-1) ;
-	
-	
+	const std::vector<std::pair<double,double> > data = lsquant::reconstruct_kubo(mu, lsquant::KUBO_BASTIN);
 
-
-
-	std::cout<<"Computing the KuboBastin kernel using "<<mu.HighestMomentNumber(0)<<" x "<<mu.HighestMomentNumber(1)<<" moments "<<std::endl;
-	std::cout<<"Integrated over a grid normalized grid  ("<<-xbound<<","<<xbound<<") in steps of "<<energies[1] - energies[0]<< std::endl;
-	std::cout<<"The first 10 moments are"<<std::endl;
-	for(int m0 =0 ; m0< 1; m0++ )
-	for(int m1 =0 ; m1< 10; m1++ )
-		std::cout<<mu(m0,m1).real()<<" "<<mu(m0,m1).imag()<<std::endl;
-	
-
-	std::string
-	outputName  ="KuboBastin_"+mu.SystemLabel()+"JACKSON.dat";
-
-	std::cout<<"Saving the data in "<<outputName<<std::endl;
-	std::cout<<"PARAMETERS: "<< mu.SystemSize()<<" "<<mu.HalfWidth()<<std::endl;
-	std::ofstream outputfile( outputName.c_str() );
-
-	std::vector<double> kernel(num_div,0.0);
-	#pragma omp parallel for
-	for( int i=0; i < num_div; i++)
-	{
-		const double energ = energies[i];
-		for( int m0 = 0 ; m0 < mu.HighestMomentNumber(0) ; m0++)
-		for( int m1 = 0 ; m1 < mu.HighestMomentNumber(1) ; m1++)
-			kernel[i] += delta_chebF(energ,m0)*( DgreenR_chebF(energ,m1)*mu(m0,m1) ).imag() ;
-		kernel[i] *= -2.0* mu.SystemSize()*mu.ScaleFactor()*mu.ScaleFactor();
-	}
-
-	double acc = 0;
-	for( int i=0; i < num_div-1; i++)
-	{
-		const double energ  = energies[i];
-		const double denerg = energies[i+1]-energies[i];
-		acc +=kernel[i]*denerg;
-		outputfile<<energ/mu.ScaleFactor() - mu.ShiftFactor() <<" "<<acc <<std::endl;
-	}
-
+	const std::string outputName = "KuboBastin_" + mu.SystemLabel() + "JACKSON.dat";
+	std::cout << "Saving the data in " << outputName << std::endl;
+	std::cout << "PARAMETERS: " << mu.SystemSize() << " " << mu.HalfWidth() << std::endl;
+	std::ofstream outputfile(outputName.c_str());
+	for (size_t i = 0; i < data.size(); ++i)
+		outputfile << data[i].first << " " << data[i].second << std::endl;
 	outputfile.close();
 
-	std::cout<<"The program finished succesfully."<<std::endl;
-return 0;
+	std::cout << "The program finished succesfully." << std::endl;
+	return 0;
 }
-	
 
 void printHelpMessage()
 {
-	std::cout << "The program should be called with the following options: moments_filename broadening(meV)" << std::endl
-			  << std::endl;
+	std::cout << "The program should be called with the following options: moments_filename broadening(meV)" << std::endl << std::endl;
 	std::cout << "moments_filename will be used to look for .chebmom2D file" << std::endl;
 	std::cout << "broadening in (meV) will define the broadening of the delta functions" << std::endl;
-};
+}
 
 void printWelcomeMessage()
 {
 	std::cout << "WELCOME: This program will compute the chebyshev sum of the kubo-bastin formula for non equlibrium properties" << std::endl;
-};
+}

--- a/src/kuboGreenwoodFromChebmom.cpp
+++ b/src/kuboGreenwoodFromChebmom.cpp
@@ -1,104 +1,58 @@
-		
+
 // C & C++ libraries
 #include <iostream>		/* for std::cout mostly */
 #include <string>		/* for std::string class */
 #include <fstream>		/* for std::ofstream and std::ifstream functions classes*/
 #include <vector>		/* for std::vector mostly class*/
 #include <complex>		/* for std::vector mostly class*/
-#include <omp.h>
 
-#include "chebyshev_solver.hpp"
-#include "chebyshev_coefficients.hpp"
 #include "chebyshev_moments.hpp"
+#include "observable.hpp"
+
+// Thin wrapper (Phase 5): Kubo-Greenwood is the Fermi-surface (N x 1) degenerate case of
+// Kubo-Bastin -- same double-Chebyshev sum, half the prefactor, no Fermi-sea integral. It now
+// runs through the unified lsquant::reconstruct_kubo with the KUBO_GREENWOOD observable.
+// (The Bug-1 fix -- prefactor -SystemSize*ScaleFactor^2, not *ShiftFactor -- lives in the
+// KUBO_GREENWOOD definition; the greenwood_regression test guards it.)
 
 void printHelpMessage();
 void printWelcomeMessage();
 
 int main(int argc, char *argv[])
-{	
-	if (argc != 3)
-	{
-		printHelpMessage();
-		return 0;
-	}
-	else
-		printWelcomeMessage();
+{
+	if (argc != 3) { printHelpMessage(); return 0; }
+	printWelcomeMessage();
 
-	const double broadening  = stod(argv[2]);
+	const double broadening = stod(argv[2]);
 
+	chebyshev::Moments2D mu(argv[1]);
+	mu.ApplyJacksonKernel(broadening, broadening);
 
-	//Read the chebyshev moments from the file
- 	chebyshev::Moments2D mu(argv[1]); 
-	//and apply the appropiated kernel
-	mu.ApplyJacksonKernel(broadening,broadening);
+	std::cout << "Computing the Kubo-Greenwood reconstruction using "
+	          << mu.HighestMomentNumber(0) << " x " << mu.HighestMomentNumber(1) << " moments" << std::endl;
 
-	const int num_div = mu.HighestMomentNumber();
-	
-	const double
-	xbound = chebyshev::safety_factors().recon_cutoff;
-		
-	std::vector< double >  energies(num_div,0);
-	for( int i=0; i < num_div; i++)
-		energies[i] = -xbound + i*(2*xbound)/(num_div-1) ;
+	const std::vector<std::pair<double,double> > data = lsquant::reconstruct_kubo(mu, lsquant::KUBO_GREENWOOD);
 
-
-
-	std::cout<<"Computing the KuboBastin kernel using "<<mu.HighestMomentNumber(0)<<" x "<<mu.HighestMomentNumber(1)<<" moments "<<std::endl;
-	std::cout<<"Integrated over a grid normalized grid  ("<<-xbound<<","<<xbound<<") in steps of "<<energies[1] - energies[0]<< std::endl;
-	std::cout<<"The first 10 moments are"<<std::endl;
-	for(int m0 =0 ; m0< 1; m0++ )
-	for(int m1 =0 ; m1< 10; m1++ )
-		std::cout<<mu(m0,m1).real()<<" "<<mu(m0,m1).imag()<<std::endl;
-	
-
-	std::string
-	outputName  ="KuboGreenWood_"+mu.SystemLabel()+"JACKSON.dat";
-
-	std::cout<<"Saving the data in "<<outputName<<std::endl;
-	std::cout<<"PARAMETERS: "<< mu.SystemSize()<<" "<<mu.HalfWidth()<<std::endl;
-	std::ofstream outputfile( outputName.c_str() );
-
-	std::vector<double> kernel(num_div,0.0);
-	#pragma omp parallel for
-	for( int i=0; i < num_div; i++)
-	{
-		double out = 0.0;
-		const double energ = energies[i];
-		for( int m0 = 0 ; m0 < mu.HighestMomentNumber(0) ; m0++)
-		for( int m1 = 0 ; m1 < mu.HighestMomentNumber(1) ; m1++)
-			out += delta_chebF(energ,m0)*( greenR_chebF(energ,m1)*mu(m0,m1) ).imag() ;
-		
-		// Bug 1 fix: the second factor was ShiftFactor(), which is
-		// -BandCenter/HalfWidth*CUTOFF = 0 for any band centred at E=0 (clean chain,
-		// graphene, every particle-hole-symmetric system) -> sigma_KG was identically 0.
-		// It must be a second ScaleFactor(): the Kubo-Greenwood prefactor is
-		// -SystemSize*ScaleFactor^2 (half the Kubo-Bastin -2*SystemSize*ScaleFactor^2,
-		// since Bastin's Fermi-sea term doubles the surface term). Calibrated on a
-		// disordered chain (W=1, exact trace): Greenwood sigma_xx(E) then matches the
-		// Chern-validated Bastin route to ~5%, and the magnitude (~40 e^2/h) agrees with
-		// the Drude estimate. ShiftFactor() remains the energy-axis shift only (below).
-		kernel[i] =  -1.0*out*(mu.SystemSize()*mu.ScaleFactor()*mu.ScaleFactor() );
-	}
-
-	for( int i=0; i < num_div-1; i++)
-		outputfile<<energies[i]/mu.ScaleFactor() - mu.ShiftFactor() <<" "<<kernel[i] <<std::endl;
-
+	const std::string outputName = "KuboGreenWood_" + mu.SystemLabel() + "JACKSON.dat";
+	std::cout << "Saving the data in " << outputName << std::endl;
+	std::cout << "PARAMETERS: " << mu.SystemSize() << " " << mu.HalfWidth() << std::endl;
+	std::ofstream outputfile(outputName.c_str());
+	for (size_t i = 0; i < data.size(); ++i)
+		outputfile << data[i].first << " " << data[i].second << std::endl;
 	outputfile.close();
 
-	std::cout<<"The program finished succesfully."<<std::endl;
-return 0;
+	std::cout << "The program finished succesfully." << std::endl;
+	return 0;
 }
-	
 
 void printHelpMessage()
 {
-	std::cout << "The program should be called with the following options: moments_filename broadening(meV)" << std::endl
-			  << std::endl;
+	std::cout << "The program should be called with the following options: moments_filename broadening(meV)" << std::endl << std::endl;
 	std::cout << "moments_filename will be used to look for .chebmom2D file" << std::endl;
 	std::cout << "broadening in (meV) will define the broadening of the delta functions" << std::endl;
-};
+}
 
 void printWelcomeMessage()
 {
-	std::cout << "WELCOME: This program will compute the chebyshev sum of the kubo-bastin formula for non equlibrium properties" << std::endl;
-};
+	std::cout << "WELCOME: This program will compute the chebyshev sum of the kubo-greenwood formula" << std::endl;
+}

--- a/src/reconstruction.cpp
+++ b/src/reconstruction.cpp
@@ -1,0 +1,47 @@
+#include "observable.hpp"
+#include "chebyshev_coefficients.hpp"   // delta_chebF, greenR_chebF, DgreenR_chebF
+#include "recon_grid.hpp"               // chebyshev::safety_factors().recon_cutoff (alpha)
+
+namespace lsquant
+{
+	// The two formulas, as data. Greenwood = N x 1 (Fermi-surface) degenerate case of Bastin.
+	const KuboObservable KUBO_GREENWOOD = { "Kubo-Greenwood", &greenR_chebF,  -1.0,  1, false };
+	const KuboObservable KUBO_BASTIN    = { "Kubo-Bastin",    &DgreenR_chebF, -2.0, 30, true  };
+
+	std::vector<std::pair<double,double> >
+	reconstruct_kubo(chebyshev::Moments2D& mu, const KuboObservable& obs)
+	{
+		const int    num_div = obs.num_div_mult * mu.HighestMomentNumber();
+		const double xbound  = chebyshev::safety_factors().recon_cutoff;   // alpha
+
+		std::vector<double> energies(num_div, 0.0);
+		for (int i = 0; i < num_div; ++i)
+			energies[i] = -xbound + i * (2 * xbound) / (num_div - 1);
+
+		// sigma kernel per energy: prefactor * N * ScaleFactor^2 * sum_{m,n} delta(E,m) Im[green(E,n) mu_{mn}]
+		std::vector<double> kernel(num_div, 0.0);
+		#pragma omp parallel for
+		for (int i = 0; i < num_div; ++i)
+		{
+			double out = 0.0;
+			const double energ = energies[i];
+			for (int m0 = 0; m0 < mu.HighestMomentNumber(0); ++m0)
+			for (int m1 = 0; m1 < mu.HighestMomentNumber(1); ++m1)
+				out += delta_chebF(energ, m0) * ( obs.green(energ, m1) * mu(m0, m1) ).imag();
+			kernel[i] = obs.prefactor * out * ( mu.SystemSize() * mu.ScaleFactor() * mu.ScaleFactor() );
+		}
+
+		// Output on the physical-energy axis. Bastin integrates the kernel cumulatively
+		// (Fermi sea); Greenwood reports the kernel directly (Fermi surface). Both emit num_div-1.
+		std::vector<std::pair<double,double> > result;
+		result.reserve(num_div > 0 ? num_div - 1 : 0);
+		double acc = 0.0;
+		for (int i = 0; i < num_div - 1; ++i)
+		{
+			const double e_phys = energies[i] / mu.ScaleFactor() - mu.ShiftFactor();
+			if (obs.integrate) { acc += kernel[i] * (energies[i+1] - energies[i]); result.push_back(std::make_pair(e_phys, acc)); }
+			else               { result.push_back(std::make_pair(e_phys, kernel[i])); }
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
## Summary
First slice of Phase 5 (reconstruction unification). Collapses the Kubo-Greenwood and
Kubo-Bastin drivers into one routine parameterized by data. **Output byte-identical to the
pre-refactor drivers; ctest 18/18.**

Greenwood is the Fermi-surface (N×1) degenerate case of Bastin — same double-Chebyshev sum,
differing only in four fields:

| field | Greenwood | Bastin |
|---|---|---|
| n-kernel | `greenR_chebF` | `DgreenR_chebF` |
| prefactor | −1 | −2 |
| grid refinement | 1× | 30× |
| integrate | no (Fermi surface) | yes (cumulative Fermi sea) |

### What landed
- **`include/observable.hpp` + `src/reconstruction.cpp`** — `KuboObservable` + `reconstruct_kubo()`;
  `KUBO_GREENWOOD` / `KUBO_BASTIN` as data.
- **`kuboBastinFromChebmom` / `kuboGreenwoodFromChebmom`** — now thin wrappers (read → kernel →
  pick observable → write). The Bug-1 Greenwood prefactor lives in `KUBO_GREENWOOD`.

### Verification
- **Byte-identical** to the pre-refactor drivers (graphene VX-VX, both Kubo & Greenwood) — exact, not just within tolerance.
- ctest **18/18**: `greenwood_regression`, `hall_haldane`, `reconstruction_nan_guard` all pass through the unified routine.

## Multi-slice note
Phase 5 is large; this is slice 1 (the Kubo family). Remaining slices: the 1-D spectral/DOS
reconstruction + re-pointing the Phase-R oracle at it; the FFT-node grid as a second backend;
and the rest (`BastinI/II/Sea/Surf`, optical, localDensities, timeCorrelations). No 🔒 in this
phase. **Not auto-merged** — it's the reconstruction subsystem you asked to review; byte-identity
proof above, safe to merge. Tell me to merge + continue, or to keep slicing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)