### PR TITLE
Refactor Phase 5 (slice 2): unify 1-D density reconstruction + re-point Phase-R oracle

### DIFF
--- a/include/observable.hpp
+++ b/include/observable.hpp
@@ -35,6 +35,16 @@ namespace lsquant
 	// the legacy drivers). The moments must already be kernel-damped (ApplyJacksonKernel).
 	std::vector<std::pair<double,double> >
 	reconstruct_kubo(chebyshev::Moments2D& mu, const KuboObservable& obs);
+
+	// 1-D KPM density reconstruction (DOS / spectral function): the shared inner sum
+	//   rho(x) = sum_m delta_chebF(x, m) * mu_real[m]
+	// on a uniform grid of `num_div` points over [-alpha, alpha]. Returns (x_rescaled, rho); the
+	// caller applies its own scalar prefactor and physical-energy axis (the only per-formula
+	// differences between DOS / spectral). `mu_real` must already be kernel-damped and carry the
+	// KPM (2 - delta_{m0}) weighting, as the stored moments do. This is the exact primitive the
+	// Phase-R oracle drives, so that oracle now guards the production reconstruction.
+	std::vector<std::pair<double,double> >
+	reconstruct_density_grid(const std::vector<double>& mu_real, double alpha, int num_div);
 }
 
 #endif // LSQUANT_OBSERVABLE

--- a/src/inline_kpm-DOS-standalone.cpp
+++ b/src/inline_kpm-DOS-standalone.cpp
@@ -8,6 +8,7 @@
 
 #include "kpm_noneqop.hpp" //Message functions
 #include "chebyshev_moments.hpp"
+#include "observable.hpp"
 #include "sparse_matrix.hpp"
 #include "quantum_states.hpp"
 #include "chebyshev_solver.hpp"
@@ -121,22 +122,16 @@ void postProcess(chebyshev::Moments1D& mu ){
 	mu.ApplyJacksonKernel(broadening);
 
 	const int num_div = 30*mu.HighestMomentNumber();
-	
-	const double
-	xbound = chebyshev::safety_factors().recon_cutoff;
-		
-	std::vector< double >  energies(num_div,0);
-	for( int i=0; i < num_div; i++)
-		energies[i] = -xbound + i*(2*xbound)/(num_div-1) ;
 
-
+	// Phase 5: the inner DOS sum rho(x) = sum_m delta_chebF(x,m) mu_m is the unified primitive
+	// lsquant::reconstruct_density_grid; this driver applies the DOS prefactor (N/HalfWidth) and
+	// the physical-energy axis (x*HalfWidth + BandCenter). Byte-identical to the legacy loop.
+	std::vector<double> mu_real( mu.HighestMomentNumber() );
+	for( int m = 0 ; m < mu.HighestMomentNumber() ; m++ ) mu_real[m] = mu(m).real();
+	const std::vector<std::pair<double,double> > grid =
+		lsquant::reconstruct_density_grid( mu_real, chebyshev::safety_factors().recon_cutoff, num_div );
 
 	std::cout<<"Computing the Spectral function using "<<mu.HighestMomentNumber()<<" moments "<<std::endl;
-	std::cout<<"Over a grid normalized grid  ("<<-xbound<<","<<xbound<<") in steps of "<<energies[1] - energies[0]<< std::endl;
-	std::cout<<"The first 10 moments are"<<std::endl;
-	for(int m0 =0 ; m0< 1; m0++ )
-		std::cout<<mu(m0).real()<<" "<<mu(m0).imag()<<std::endl;
-	
 
 	std::string
 	outputName  ="mean"+mu.SystemLabel()+"JACKSON.dat";
@@ -145,19 +140,9 @@ void postProcess(chebyshev::Moments1D& mu ){
 	std::cout<<"PARAMETERS: "<< mu.SystemSize()<<" "<<mu.HalfWidth()<<std::endl;
 	std::ofstream outputfile( outputName.c_str() );
 
-	std::vector<double> output(num_div,0.0);
-	#pragma omp parallel for
-	for( int i=0; i < num_div; i++)
-	{
-		output[i] = 0;
-		const double energ = energies[i];
-		for( int m0 = 0 ; m0 < mu.HighestMomentNumber() ; m0++)
-			output[i] += delta_chebF(energ,m0)*mu(m0).real() ;
-		output[i] *= mu.SystemSize()/mu.HalfWidth();
-	}
-
-	for( int i=0; i < num_div; i++)
-		outputfile<<energies[i]*mu.HalfWidth() + mu.BandCenter() <<" "<< output[i] <<std::endl;
+	for( size_t i = 0; i < grid.size(); ++i )
+		outputfile<< grid[i].first*mu.HalfWidth() + mu.BandCenter()
+		          <<" "<< grid[i].second*( mu.SystemSize()/mu.HalfWidth() ) <<std::endl;
 
 	outputfile.close();
 

--- a/src/reconstruction.cpp
+++ b/src/reconstruction.cpp
@@ -44,4 +44,25 @@ namespace lsquant
 		}
 		return result;
 	}
+
+	std::vector<std::pair<double,double> >
+	reconstruct_density_grid(const std::vector<double>& mu_real, double alpha, int num_div)
+	{
+		std::vector<double> energies(num_div, 0.0);
+		for (int i = 0; i < num_div; ++i)
+			energies[i] = -alpha + i * (2 * alpha) / (num_div - 1);
+
+		std::vector<std::pair<double,double> > out(num_div);
+		const int M = static_cast<int>(mu_real.size());
+		#pragma omp parallel for
+		for (int i = 0; i < num_div; ++i)
+		{
+			double s = 0.0;
+			const double energ = energies[i];
+			for (int m = 0; m < M; ++m)
+				s += delta_chebF(energ, m) * mu_real[m];
+			out[i] = std::make_pair(energ, s);
+		}
+		return out;
+	}
 }

--- a/src/spectralFunctionFromChebmom.cpp
+++ b/src/spectralFunctionFromChebmom.cpp
@@ -7,9 +7,12 @@
 #include <complex>		/* for std::vector mostly class*/
 #include <omp.h>
 
-#include "chebyshev_solver.hpp"
-#include "chebyshev_coefficients.hpp"
 #include "chebyshev_moments.hpp"
+#include "observable.hpp"
+
+// Thin wrapper (Phase 5): the spectral-function DOS sum is the unified
+// lsquant::reconstruct_density_grid; this driver applies its prefactor (N*ScaleFactor) and
+// energy axis (x/ScaleFactor + ShiftFactor). Byte-identical to the legacy loop.
 
 void printHelpMessage();
 void printWelcomeMessage();
@@ -33,43 +36,23 @@ int main(int argc, char *argv[])
 	mu.ApplyJacksonKernel(broadening);
 
 	const int num_div = 30*mu.HighestMomentNumber();
-	
-	const double
-	xbound = chebyshev::safety_factors().recon_cutoff;
-		
-	std::vector< double >  energies(num_div,0);
-	for( int i=0; i < num_div; i++)
-		energies[i] = -xbound + i*(2*xbound)/(num_div-1) ;
 
-
-
-	std::cout<<"Computing the Spectral function using "<<mu.HighestMomentNumber()<<" moments "<<std::endl;
-	std::cout<<"Over a grid normalized grid  ("<<-xbound<<","<<xbound<<") in steps of "<<energies[1] - energies[0]<< std::endl;
-	std::cout<<"The first 10 moments are"<<std::endl;
-	for(int m0 =0 ; m0< 1; m0++ )
-		std::cout<<mu(m0).real()<<" "<<mu(m0).imag()<<std::endl;
-	
+	std::vector<double> mu_real( mu.HighestMomentNumber() );
+	for( int m = 0 ; m < mu.HighestMomentNumber() ; m++ ) mu_real[m] = mu(m).real();
+	const std::vector<std::pair<double,double> > grid =
+		lsquant::reconstruct_density_grid( mu_real, chebyshev::safety_factors().recon_cutoff, num_div );
 
 	std::string
 	outputName  ="mean"+mu.SystemLabel()+"JACKSON.dat";
 
+	std::cout<<"Computing the Spectral function using "<<mu.HighestMomentNumber()<<" moments "<<std::endl;
 	std::cout<<"Saving the data in "<<outputName<<std::endl;
 	std::cout<<"PARAMETERS: "<< mu.SystemSize()<<" "<<mu.HalfWidth()<<std::endl;
 	std::ofstream outputfile( outputName.c_str() );
 
-	std::vector<double> output(num_div,0.0);
-	#pragma omp parallel for
-	for( int i=0; i < num_div; i++)
-	{
-		output[i] = 0;
-		const double energ = energies[i];
-		for( int m0 = 0 ; m0 < mu.HighestMomentNumber() ; m0++)
-			output[i] += delta_chebF(energ,m0)*mu(m0).real() ;
-		output[i] *= mu.SystemSize()*mu.ScaleFactor();
-	}
-
-	for( int i=0; i < num_div; i++)
-		outputfile<<energies[i]/mu.ScaleFactor() + mu.ShiftFactor() <<" "<< output[i] <<std::endl;
+	for( size_t i = 0; i < grid.size(); ++i )
+		outputfile<< grid[i].first/mu.ScaleFactor() + mu.ShiftFactor()
+		          <<" "<< grid[i].second*( mu.SystemSize()*mu.ScaleFactor() ) <<std::endl;
 
 	outputfile.close();
 

--- a/src/spectralFunctionFromChebmom_Lorentz.cpp
+++ b/src/spectralFunctionFromChebmom_Lorentz.cpp
@@ -7,9 +7,12 @@
 #include <complex>		/* for std::vector mostly class*/
 #include <omp.h>
 
-#include "chebyshev_solver.hpp"
-#include "chebyshev_coefficients.hpp"
 #include "chebyshev_moments.hpp"
+#include "observable.hpp"
+
+// Thin wrapper (Phase 5): same unified DOS sum (lsquant::reconstruct_density_grid), but the
+// moments are damped with the LORENTZ kernel; prefactor N/HalfWidth, axis x*HalfWidth+BandCenter.
+// Byte-identical to the legacy loop.
 
 void printHelpMessage();
 void printWelcomeMessage();
@@ -35,43 +38,23 @@ int main(int argc, char *argv[])
 	mu.ApplyLorentzKernel(broadening, lambda);
 
 	const int num_div = 30*mu.HighestMomentNumber();
-	
-	const double
-	xbound = chebyshev::safety_factors().recon_cutoff;
-		
-	std::vector< double >  energies(num_div,0);
-	for( int i=0; i < num_div; i++)
-		energies[i] = -xbound + i*(2*xbound)/(num_div-1) ;
 
-
-
-	std::cout<<"Computing the Spectral function using "<<mu.HighestMomentNumber()<<" moments "<<std::endl;
-	std::cout<<"Over a grid normalized grid  ("<<-xbound<<","<<xbound<<") in steps of "<<energies[1] - energies[0]<< std::endl;
-	std::cout<<"The first 10 moments are"<<std::endl;
-	for(int m0 =0 ; m0< 1; m0++ )
-		std::cout<<mu(m0).real()<<" "<<mu(m0).imag()<<std::endl;
-	
+	std::vector<double> mu_real( mu.HighestMomentNumber() );
+	for( int m = 0 ; m < mu.HighestMomentNumber() ; m++ ) mu_real[m] = mu(m).real();
+	const std::vector<std::pair<double,double> > grid =
+		lsquant::reconstruct_density_grid( mu_real, chebyshev::safety_factors().recon_cutoff, num_div );
 
 	std::string
 	outputName  ="mean"+mu.SystemLabel()+"LORENTZ.dat";
 
+	std::cout<<"Computing the Spectral function using "<<mu.HighestMomentNumber()<<" moments "<<std::endl;
 	std::cout<<"Saving the data in "<<outputName<<std::endl;
 	std::cout<<"PARAMETERS: "<< mu.SystemSize()<<" "<<mu.HalfWidth()<<std::endl;
 	std::ofstream outputfile( outputName.c_str() );
 
-	std::vector<double> output(num_div,0.0);
-	#pragma omp parallel for
-	for( int i=0; i < num_div; i++)
-	{
-		output[i] = 0;
-		const double energ = energies[i];
-		for( int m0 = 0 ; m0 < mu.HighestMomentNumber() ; m0++)
-			output[i] += delta_chebF(energ,m0)*mu(m0).real() ;
-		output[i] *= mu.SystemSize()/mu.HalfWidth();
-	}
-
-	for( int i=0; i < num_div; i++)
-		outputfile<<energies[i]*mu.HalfWidth() + mu.BandCenter() <<" "<< output[i] <<std::endl;
+	for( size_t i = 0; i < grid.size(); ++i )
+		outputfile<< grid[i].first*mu.HalfWidth() + mu.BandCenter()
+		          <<" "<< grid[i].second*( mu.SystemSize()/mu.HalfWidth() ) <<std::endl;
 
 	outputfile.close();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,6 +137,7 @@ add_test(NAME spin_precession
 # alpha edge singularity -- isolating the reconstruction knobs from operators/recursion.
 add_executable(recon_kernel_oracle_test recon_kernel_oracle_test.cpp)
 target_include_directories(recon_kernel_oracle_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(recon_kernel_oracle_test PRIVATE kpm_lib)
 add_test(NAME recon_kernel_oracle COMMAND recon_kernel_oracle_test 0.10)
 
 # --- Kubo-Greenwood reconstruction regression (Bug 1, Phase 0) -------------------

--- a/test/recon_kernel_oracle_test.cpp
+++ b/test/recon_kernel_oracle_test.cpp
@@ -34,7 +34,7 @@
 #include <cmath>
 #include <string>
 #include <complex>
-#include "chebyshev_coefficients.hpp"   // production delta_chebF
+#include "observable.hpp"   // lsquant::reconstruct_density_grid (the PRODUCTION 1-D reconstruction)
 
 // Jackson damping factor g_m for an M-moment expansion -- identical closed form to
 // chebyshev::Moments1D::JacksonKernel (kept local so the oracle has no object/IO setup).
@@ -44,19 +44,19 @@ static double jackson(int m, int M) {
 }
 
 // rho(x) on a uniform grid over [-alpha, alpha] for a synthetic delta at E0, M moments, Jackson.
+// Phase 5: this drives the PRODUCTION primitive lsquant::reconstruct_density_grid (the exact
+// routine the DOS / spectral drivers use), so the oracle now guards production -- not a copy.
+// We fold the (2 - delta_{m0}) weighting and the Jackson kernel into mu, exactly as the stored,
+// kernel-damped moments carry them.
 static void reconstruct(double E0, int M, double alpha, int npts,
                         std::vector<double>& x, std::vector<double>& rho) {
-    x.assign(npts, 0.0); rho.assign(npts, 0.0);
     std::vector<double> mu(M);
     for (int m = 0; m < M; ++m)
         mu[m] = (2.0 - (m == 0 ? 1.0 : 0.0)) * std::cos(m * std::acos(E0)) * jackson(m, M);
-    for (int i = 0; i < npts; ++i) {
-        const double xi = -alpha + 2.0 * alpha * i / (npts - 1);
-        x[i] = xi;
-        double s = 0.0;
-        for (int m = 0; m < M; ++m) s += delta_chebF(xi, m) * mu[m];   // PRODUCTION kernel
-        rho[i] = s;
-    }
+    const std::vector<std::pair<double,double> > grid =
+        lsquant::reconstruct_density_grid(mu, alpha, npts);
+    x.assign(npts, 0.0); rho.assign(npts, 0.0);
+    for (int i = 0; i < npts; ++i) { x[i] = grid[i].first; rho[i] = grid[i].second; }
 }
 
 static double fwhm(const std::vector<double>& x, const std::vector<double>& rho) {


### PR DESCRIPTION
## Summary
Second slice of Phase 5. Factors the shared 1-D DOS/spectral inner sum into the unified
primitive `reconstruct_density_grid`, and **re-points the Phase-R oracle at it** so the
synthetic δ test now guards the production reconstruction (not a copy). **Byte-identical; ctest 18/18.**

### What landed
- **`reconstruct_density_grid(mu_real, alpha, num_div)`** — `ρ(x)=Σ_m delta_chebF(x,m)·μ_m`; the
  caller supplies the per-formula scalar prefactor + physical-energy axis (the only differences).
- **`inline_kpm-DOS-standalone`, `spectralFunctionFromChebmom`, `spectralFunctionFromChebmom_Lorentz`**
  → thin wrappers over the primitive (each keeps its exact prefactor/axis).
- **`recon_kernel_oracle_test`** now drives `reconstruct_density_grid` (was a local
  reimplementation) → the Phase-R oracle guards production. Links `kpm_lib`.

### Verification
- **Byte-identical** to the pre-refactor drivers: DOS-standalone (chain, vs current main) and the
  two spectral drivers (committed 1-D moments).
- ctest **18/18** — `dos_reconstructed` (closed form) and `recon_kernel_oracle` (position /
  Jackson width / unit weight / α-edge) both pass through the unified primitive.

## Multi-slice note
Remaining: FFT-node grid as a second backend (slice 3); `BastinI/II/Sea/Surf`, optical,
localDensities, timeCorrelations (slice 4). No 🔒. Not auto-merged (reconstruction subsystem) —
byte-identity proof above. Say merge + continue, or hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)