### PR TITLE
Refactor Phase 5 (final): reconstruction architecture doc + secondary-driver evaluation map

### DIFF
--- a/docs/linqt.dox
+++ b/docs/linqt.dox
@@ -781,7 +781,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = main.md spectral_scales.md time_evolution.md spinrelaxation.md ../include ../src
+INPUT                  = main.md spectral_scales.md reconstruction.md time_evolution.md spinrelaxation.md ../include ../src
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv

--- a/docs/reconstruction.md
+++ b/docs/reconstruction.md
@@ -1,0 +1,67 @@
+# Reconstruction architecture (Phase 5)   {#reconstruction}
+
+How KPM moment tables become `.dat` spectra/conductivities, after the Phase-5 unification.
+"A formula is a piece of data, not an executable" — the reconstruction logic lives in one
+place; each driver is a thin wrapper that picks a formula (and grid backend) and writes a file.
+
+---
+
+## Unified core — `include/observable.hpp`, `src/reconstruction.cpp`
+
+- **`KuboObservable`** — the formula as data: `{green-kernel, prefactor, num_div_mult, integrate}`.
+  `KUBO_GREENWOOD = {greenR, −1, 1, false}` is the Fermi-surface (N×1) degenerate case of
+  `KUBO_BASTIN = {DgreenR, −2, 30, true}`.
+- **`reconstruct_kubo(mu, obs, grid)`** — the shared double-Chebyshev integrand
+  `Σ_{m,n} delta_chebF(E,m) Im[green(E,n) μ_{mn}]`, with two grid backends:
+  - `GRID_UNIFORM` — 30·M points on `[-α, α]` (α = `safety_factors().recon_cutoff`),
+  - `GRID_FFT_NODES` — M Chebyshev nodes (rearranged ascending for the Bastin integral).
+- **`reconstruct_density_grid(μ_real, α, num_div)`** — the shared 1-D DOS/spectral inner sum
+  `Σ_m delta_chebF(E,m) μ_m`. Callers add their scalar prefactor and physical-energy axis.
+- The **`recon_kernel_oracle`** test (Phase R) *drives* `reconstruct_density_grid` with a
+  synthetic δ of known moments, so the production reconstruction is guarded operator-free.
+
+## Drivers — what is unified, and the gate
+
+| driver | formula / route | gated by |
+|---|---|---|
+| `inline_kpm-DOS-standalone` | DOS, `reconstruct_density_grid` | `dos_reconstructed`, `recon_kernel_oracle` |
+| `spectralFunctionFromChebmom` | spectral, density grid | byte-identity (1-D moments) |
+| `spectralFunctionFromChebmom_Lorentz` | spectral + Lorentz kernel | byte-identity |
+| `kuboGreenwoodFromChebmom` | `reconstruct_kubo(KUBO_GREENWOOD, UNIFORM)` | `greenwood_regression` |
+| `kuboBastinFromChebmom` | `reconstruct_kubo(KUBO_BASTIN, UNIFORM)` | `hall_haldane`, `reconstruction_nan_guard` |
+| `kuboGreenwoodFromChebmom_FFTgrid` | `KUBO_GREENWOOD, FFT_NODES` | `fft_grid_regression` |
+| `kuboBastinFromChebmom_FFTgrid` | `KUBO_BASTIN, FFT_NODES` | `fft_grid_regression` |
+
+All seven are byte-identical to their pre-refactor binaries.
+
+---
+
+## Secondary reconstructions — NOT yet unified, NO regression golden
+
+These are alternative / experimental formulations with **distinct integrands** (not just
+`green` vs `Dgreen`), and none has a golden test. They are **out of scope for the structural
+unification** and are flagged for a post-refactor evaluation: for each, decide *unify* (needs a
+generalized `Integrand` and a golden), *rewrite*, or *remove*. Do not rely on any of them until
+it has a regression test.
+
+| driver | distinct integrand | note |
+|---|---|---|
+| `kuboBastinIFromChebmom` | Greenwood integrand `delta·Im(greenR·μ)` + trapezoid output | near-duplicate of Greenwood |
+| `kuboBastinIIFromChebmom` | `−Re[(GrL·DGrR − DGrL·GrR)·μ]`, prefactor `/2π` | products of green & d-green on both indices |
+| `kuboBastinSeaFromChebmom` | `−Re[(Gr−Ga)(DGr+DGa)·μ]` | retarded/advanced Fermi-sea form |
+| `kuboBastinSurfFromChebmom` | `delta·delta·μ`, prefactor `π·N·SF²` | double-delta Fermi-surface form |
+| `opticalConductivityFromChebmom` | frequency-shifted `greenR(x ± w)` | finite-frequency; needs a frequency arg |
+| `localDensitiesFromChebmom` | local (site-resolved) density | different observable shape |
+| `timeCorrelationsFromChebmom` | time-domain `MomentsTD` projection | belongs with the TD family |
+| `spectralFunctionFromChebmom_FFTgrid` | 1-D density on `cos(π(i+½)/M)` nodes, writes `abs(ρ)` | quirky node formula + abs |
+
+Compute-side: `Kubo_solver_FFT` still carries its own `enum formula {KUBO_GREENWOOD, KUBO_BASTIN}`
+(the FFT solver that computes *and* reconstructs); folding it onto the shared formula identity is
+part of the same evaluation, and is gated only once that path has a test.
+
+### A latent finding for the evaluation
+The **uniform-grid** Kubo drivers write the energy axis as `E/ScaleFactor − ShiftFactor`
+= `E·HalfWidth + BandCenter/HalfWidth`, whereas the **FFT-grid** and DOS drivers use
+`E·HalfWidth + BandCenter`. These agree only for a band centred at E=0 (all current goldens), so
+the `+BandCenter/HalfWidth` term looks like a latent bug for off-centre bands. Confirm and fix
+under a non-centred golden during the evaluation.


### PR DESCRIPTION
## Summary
Concludes Phase 5. **Docs-only.** `docs/reconstruction.md` records the unified reconstruction
architecture and the inventory that sets up the post-refactor evaluation of the untested
secondary drivers.

- **Unified core**: `KuboObservable` (formula as data), `reconstruct_kubo` with
  `GRID_UNIFORM`/`GRID_FFT_NODES`, `reconstruct_density_grid`, guarded by the Phase-R oracle.
- **7 unified drivers** (DOS, spectral ×2, Greenwood, Bastin, ±FFT) — table with their gating
  tests; all byte-identical to pre-refactor.
- **7 secondary drivers** NOT unified (`kuboBastinI/II/Sea/Surf`, optical, localDensities,
  timeCorrelations, `spectral_FFTgrid`) + the compute-side `Kubo_solver_FFT` enum — each with its
  **distinct integrand** (retarded/advanced products, double-δ, frequency-shifted greenR,
  time-domain) and the note that **none has a golden**. Flagged for the agreed post-refactor
  evaluation (unify-with-golden / rewrite / remove).
- Records a **latent finding**: the uniform-grid Kubo energy axis uses `+BandCenter/HalfWidth`
  vs `+BandCenter` elsewhere (agree only for centred bands).

ctest **19/19** unchanged. Docs-only, no 🔒 — merging per the standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)