### PR TITLE
Phase 6 (placeholders): HamiltonianOp + MetricPolicy interfaces

### DIFF
--- a/include/hamiltonian_op.hpp
+++ b/include/hamiltonian_op.hpp
@@ -1,0 +1,60 @@
+#ifndef LSQUANT_HAMILTONIAN_OP
+#define LSQUANT_HAMILTONIAN_OP
+
+#include <vector>
+#include <complex>
+#include <cstddef>
+#include <stdexcept>
+
+// Phase 6 SCAFFOLDING (interface only -- the core is not migrated onto it yet).
+//
+// Today the KPM core takes a concrete SparseMatrixType*. Phase 6 will have it consume this
+// HamiltonianOp interface instead, so the stored-sparse matrix and the on-the-fly ("matrix-free")
+// analytic models (Graphene_NNN / Device) become two implementations of one contract rather than
+// forked solver/moments/vectors files.
+//
+// DESIGN RULE: virtual dispatch is at "apply to a whole vector" granularity (multiply), NEVER
+// per matrix element -- so the hot Chebyshev recursion pays one virtual call per matvec. The
+// descriptor/sidecar (identity, units, bounds) never enters here; this is numeric buffers only.
+//
+// STATUS: the sparse adapter and the matrix-free implementation are deferred to Phase 6. The
+// matrix-free placeholder below exists so callers can compile against the final interface and so
+// the boundary is explicit; it throws until implemented (it must never be silently a no-op).
+
+namespace lsquant
+{
+	class HamiltonianOp
+	{
+	public:
+		typedef std::complex<double>   scalar;
+		typedef std::vector<scalar>    vector_t;
+
+		virtual ~HamiltonianOp() {}
+
+		// Hilbert-space dimension (rank of H).
+		virtual std::size_t dim() const = 0;
+
+		// y = a * H * x + b * y  -- the recursion's ONLY contact with H (matches
+		// SparseMatrixType::Multiply(a,x,b,y) so the sparse adapter is a trivial forward).
+		virtual void multiply(scalar a, const vector_t& x, scalar b, vector_t& y) const = 0;
+
+		// True if H is already rescaled into the Chebyshev domain [-1,1] (H~). The owner applies
+		// the (H - BandCenter)/HalfWidth rescale; bounds come from the operator descriptor.
+		virtual bool is_rescaled() const { return false; }
+	};
+
+	// PLACEHOLDER (Phase 6): build H*x on the fly from an analytic tight-binding model
+	// (Graphene_NNN / Device), with no stored matrix. Not implemented yet -- throws rather than
+	// pretending to work, so an accidental use is loud, not silent.
+	class MatrixFreeHamiltonianOp : public HamiltonianOp
+	{
+	public:
+		std::size_t dim() const override
+		{ throw std::logic_error("MatrixFreeHamiltonianOp: matrix-free apply not implemented yet (Phase 6)"); }
+
+		void multiply(scalar, const vector_t&, scalar, vector_t&) const override
+		{ throw std::logic_error("MatrixFreeHamiltonianOp: matrix-free apply not implemented yet (Phase 6)"); }
+	};
+}
+
+#endif // LSQUANT_HAMILTONIAN_OP

--- a/include/metric_policy.hpp
+++ b/include/metric_policy.hpp
@@ -1,0 +1,54 @@
+#ifndef LSQUANT_METRIC_POLICY
+#define LSQUANT_METRIC_POLICY
+
+#include <vector>
+#include <complex>
+#include <stdexcept>
+
+// Phase 6 SCAFFOLDING (interface only -- not wired into the core yet).
+//
+// Non-orthogonality becomes a POLICY rather than a forked code path (the current `_nonOrth`
+// files). An orthogonal basis uses the identity metric (today's behaviour). A non-orthogonal
+// basis carries an overlap matrix S, and the Chebyshev recursion must work against S^{-1}
+// (solve S y = x each step; iterative CG when S is matrix-free).
+//
+// STATUS: OrthogonalMetric is the real, trivial default (identity). NonOrthogonalMetric is a
+// PLACEHOLDER (throws) -- the S-solve lands in Phase 6, with the CG tolerance as that phase's
+// only human checkpoint, guarded by kpm-nonOrth-precision-test.
+
+namespace lsquant
+{
+	class MetricPolicy
+	{
+	public:
+		typedef std::complex<double>   scalar;
+		typedef std::vector<scalar>    vector_t;
+
+		virtual ~MetricPolicy() {}
+
+		// Apply S^{-1} in place (orthogonal basis: a no-op).
+		virtual void apply_inverse_metric(vector_t& v) const = 0;
+
+		virtual bool is_orthogonal() const = 0;
+	};
+
+	// Orthogonal basis: S = I, so S^{-1} is the identity. The real default behaviour.
+	class OrthogonalMetric : public MetricPolicy
+	{
+	public:
+		void apply_inverse_metric(vector_t& /*v*/) const override { /* identity: nothing to do */ }
+		bool is_orthogonal() const override { return true; }
+	};
+
+	// PLACEHOLDER (Phase 6): non-orthogonal basis -- solve S y = v (CG when S is matrix-free).
+	// Not implemented yet -- throws so an accidental use cannot silently behave as orthogonal.
+	class NonOrthogonalMetric : public MetricPolicy
+	{
+	public:
+		void apply_inverse_metric(vector_t& /*v*/) const override
+		{ throw std::logic_error("NonOrthogonalMetric: S^{-1} solve not implemented yet (Phase 6)"); }
+		bool is_orthogonal() const override { return false; }
+	};
+}
+
+#endif // LSQUANT_METRIC_POLICY

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,3 +205,11 @@ add_test(NAME corrop_state_honored
 # for the GRID_FFT_NODES backend in reconstruct_kubo.
 add_test(NAME fft_grid_regression
          COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/fft_grid_regression.sh ${CMAKE_BINARY_DIR})
+
+# --- Phase 6 scaffolding contract (interfaces only) -----------------------------
+# HamiltonianOp / MetricPolicy are placeholders for the deferred Phase 6 (the core is not
+# migrated onto them yet). This pins the contract: OrthogonalMetric is the identity; the
+# matrix-free and non-orthogonal placeholders THROW (never a silent no-op).
+add_executable(phase6_scaffolding_test phase6_scaffolding_test.cpp)
+target_include_directories(phase6_scaffolding_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME phase6_scaffolding COMMAND phase6_scaffolding_test)

--- a/test/phase6_scaffolding_test.cpp
+++ b/test/phase6_scaffolding_test.cpp
@@ -1,0 +1,52 @@
+// Phase 6 scaffolding contract (interfaces only -- the core is not migrated yet).
+//
+// Pins two things so the placeholders cannot rot or be mistaken for working code:
+//   (1) the REAL default behaviours -- OrthogonalMetric is the identity S^{-1};
+//   (2) the PLACEHOLDERS are loud -- MatrixFreeHamiltonianOp and NonOrthogonalMetric THROW
+//       (a silent no-op would be a correctness trap when the hot loop is migrated in Phase 6).
+#include <iostream>
+#include <complex>
+#include <vector>
+#include <stdexcept>
+#include "hamiltonian_op.hpp"
+#include "metric_policy.hpp"
+
+static int g_fail = 0;
+static void check(bool ok, const std::string& what) {
+    std::cout << (ok ? "  OK   " : "  FAIL ") << what << "\n";
+    if (!ok) g_fail = 1;
+}
+template <class F>
+static bool throws(F f) { try { f(); return false; } catch (const std::logic_error&) { return true; } catch (...) { return false; } }
+
+int main() {
+    typedef std::complex<double> cd;
+
+    // (1) OrthogonalMetric: identity S^{-1}, leaves the vector untouched.
+    std::vector<cd> v;
+    v.push_back(cd(1,2)); v.push_back(cd(-3,4)); v.push_back(cd(0,0));
+    const std::vector<cd> before = v;
+    lsquant::OrthogonalMetric ortho;
+    ortho.apply_inverse_metric(v);
+    check(ortho.is_orthogonal(), "OrthogonalMetric.is_orthogonal() == true");
+    check(v == before,           "OrthogonalMetric.apply_inverse_metric is the identity");
+
+    // (2a) NonOrthogonalMetric placeholder: reports non-orthogonal AND throws (not a silent no-op).
+    lsquant::NonOrthogonalMetric nonortho;
+    check(!nonortho.is_orthogonal(), "NonOrthogonalMetric.is_orthogonal() == false");
+    std::vector<cd> w(3, cd(1,0));
+    check(throws([&]{ nonortho.apply_inverse_metric(w); }),
+          "NonOrthogonalMetric.apply_inverse_metric throws (placeholder, not implemented)");
+
+    // (2b) MatrixFreeHamiltonianOp placeholder: throws on use.
+    lsquant::MatrixFreeHamiltonianOp mf;
+    check(throws([&]{ mf.dim(); }),
+          "MatrixFreeHamiltonianOp.dim() throws (placeholder, not implemented)");
+    std::vector<cd> x(3, cd(1,0)), y(3, cd(0,0));
+    check(throws([&]{ mf.multiply(cd(1,0), x, cd(0,0), y); }),
+          "MatrixFreeHamiltonianOp.multiply() throws (placeholder, not implemented)");
+
+    if (g_fail == 0) { std::cout << "PASS: Phase-6 interfaces -- orthogonal default works, placeholders are loud\n"; return 0; }
+    std::cerr << "FAIL: Phase-6 scaffolding contract violated\n";
+    return 1;
+}


### PR DESCRIPTION
## Summary
Lands the Phase-6 interfaces as **explicit placeholders** (header-only, core not migrated). The
real Phase 6 — collapsing the `_Graphene_NNN`/`_Device`/`_nonOrth` forks onto these and migrating
the hot loop — is deferred per the agreed plan; the matrix-free and non-orthogonal paths don't
exist as correct code yet, so they're stubbed loudly. **No working code touched; ctest 20/20.**

- **`include/hamiltonian_op.hpp`** — `HamiltonianOp::multiply(a,x,b,y)` at whole-vector
  granularity (one virtual call per matvec, never per element; matches `SparseMatrixType` so the
  eventual adapter is a trivial forward). `MatrixFreeHamiltonianOp` **throws** (never a silent no-op).
- **`include/metric_policy.hpp`** — `OrthogonalMetric` is the real identity default;
  `NonOrthogonalMetric` (S⁻¹ solve, CG when matrix-free) **throws**.
- **`phase6_scaffolding` test** — pins the contract: orthogonal default is the identity; both
  placeholders throw, so the future migration can't accidentally treat them as working.

Establishes the Phase-6 boundary so Phase 7 can proceed. No 🔒 — merging per the standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)