### PR TITLE
Phase 7 (slice 1): single lsquant dispatcher binary (inspect + reconstruct)

### DIFF
--- a/include/inspect.hpp
+++ b/include/inspect.hpp
@@ -1,0 +1,15 @@
+#ifndef LSQUANT_INSPECT
+#define LSQUANT_INSPECT
+
+#include <string>
+
+namespace lsquant
+{
+	// Print what a run.json (or an operator .desc) will do, including the resolved numerical
+	// provenance (recon alpha, bounds source, hbar/units, kernel). Dispatches on the file suffix
+	// (.desc vs .json). Returns 0 on success. Shared by the standalone `lsquant_inspect` binary
+	// and the `lsquant inspect` subcommand (Phase 7).
+	int inspect_path(const std::string& path);
+}
+
+#endif // LSQUANT_INSPECT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(KPM_LIB_SOURCES
     sparse_matrix.cpp
     operator_descriptor.cpp
     run_config.cpp
+    inspect.cpp
     reconstruction.cpp
     special_functions.cpp
     Kubo_solver_FFT.cpp
@@ -97,6 +98,7 @@ set(LINQT_APPS
     "inline_compute-Kubo-kpm-FFT-nonOrth|inline_compute-Kubo-kpm-FFT-nonOrth.cpp"
     "inline_compute-kpm-TimeEvOpwithWF|inline_compute-kpm-TimeEvOpwithWF.cpp"
     "lsquant_inspect|lsquant_inspect.cpp"
+    "lsquant|lsquant.cpp"
 )
 
 foreach(entry IN LISTS LINQT_APPS)

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -1,0 +1,68 @@
+#include "inspect.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include "run_config.hpp"
+#include "operator_descriptor.hpp"
+#include "units.hpp"
+#include "recon_grid.hpp"
+
+namespace
+{
+	bool ends_with(const std::string& s, const std::string& suf) {
+		return s.size() >= suf.size() && s.compare(s.size()-suf.size(), suf.size(), suf) == 0;
+	}
+	bool file_exists(const std::string& p) { std::ifstream f(p.c_str()); return f.good(); }
+
+	void inspect_desc(const std::string& path) {
+		lsquant::OperatorDescriptor d = lsquant::read_descriptor(path);
+		std::cout << "operator descriptor: " << path << "\n";
+		if (!d.valid) { std::cout << "  (could not parse)\n"; return; }
+		std::cout << "  observable : " << d.observable << "\n"
+		          << "  component  : " << (d.component.empty() ? "(none)" : d.component) << "\n"
+		          << "  units      : " << d.units << "\n"
+		          << "  provenance : " << d.provenance << "\n";
+		if (d.has_bounds) std::cout << "  bounds(a,b): [" << d.a << ", " << d.b << "]\n";
+		if (d.has_basis)  { std::cout << "  basis      : " << d.orbitals_per_cell << " orbitals/cell x "
+		                              << d.num_cells << " cells, spins ";
+		                    for (int s : d.orbital_spin) std::cout << (s>0?'+':'-'); std::cout << "\n"; }
+	}
+
+	void inspect_run(const std::string& path) {
+		lsquant::RunConfig c = lsquant::read_run_config(path);
+		std::cout << "run config: " << path << "\n";
+		if (!c.valid) { std::cout << "  INVALID: " << c.error << "\n"; return; }
+
+		const std::string ham_desc = "operators/" + c.label + ".HAM.desc";
+		const std::string bounds_src =
+			file_exists("BOUNDS")  ? "BOUNDS file (explicit override)" :
+			file_exists(ham_desc)  ? ("descriptor " + ham_desc + " (producer Lanczos)") :
+			                         "Gershgorin enclosure + pad (fallback)";
+		const double alpha = (c.alpha >= 0.0) ? c.alpha : chebyshev::safety_factors().recon_cutoff;
+
+		std::cout << "  what runs   : <" << c.operator_left << "|.|" << c.operator_right
+		          << "> correlation on '" << c.label << "', M = " << c.num_moments << "\n"
+		          << "  state       : " << c.state << "\n"
+		          << "  kernel      : " << c.kernel;
+		if (c.kernel == "lorentz") std::cout << " (lambda = " << c.lambda << ")";
+		std::cout << "\n";
+		std::cout << "  -- numerical provenance --\n"
+		          << "  recon alpha : " << alpha << (c.alpha>=0.0 ? " (from run.json)" : " (recon_grid default/env)") << "\n"
+		          << "  bounds pad  : " << chebyshev::safety_factors().bounds_pad << "\n"
+		          << "  bounds from : " << bounds_src << "\n"
+		          << "  hbar (units): " << chebyshev::HBAR << " eV*fs\n";
+		if (file_exists(ham_desc)) { std::cout << "  -- Hamiltonian descriptor --\n"; inspect_desc(ham_desc); }
+		std::cout << "  output      : " << (c.output.empty() ? "(derived from run parameters)" : c.output) << "\n";
+	}
+}
+
+namespace lsquant
+{
+	int inspect_path(const std::string& path)
+	{
+		if (ends_with(path, ".desc")) inspect_desc(path);
+		else                          inspect_run(path);
+		return 0;
+	}
+}

--- a/src/lsquant.cpp
+++ b/src/lsquant.cpp
@@ -1,0 +1,66 @@
+// lsquant -- single-binary dispatcher (Phase 7).
+//
+// Strangler-fig: this binary grows BESIDE the legacy per-task executables (41 main()s). It
+// already subsumes the parts that the refactor has library-ized -- `inspect` (run.json / .desc)
+// and `reconstruct` (the unified Kubo reconstruction) -- and will absorb `compute` and the
+// model plugins as Phase 6/7 proceed. Subcommand style: `lsquant <command> [args...]`.
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <complex>
+
+#include "inspect.hpp"
+#include "observable.hpp"
+#include "chebyshev_moments.hpp"
+
+static int usage(const char* prog)
+{
+	std::cerr << "usage: " << prog << " <command> [args...]\n\n"
+	          << "commands:\n"
+	          << "  inspect <run.json | operator.desc>\n"
+	          << "        print a run / operator and its resolved numerical provenance\n"
+	          << "  reconstruct <moments.chebmom2D> <bastin|greenwood> <broadening_meV>\n"
+	          << "        reconstruct sigma(E) via the unified Kubo routine; writes Kubo*JACKSON.dat\n";
+	return 2;
+}
+
+static int cmd_reconstruct(int argc, char** argv)
+{
+	if (argc != 5) { std::cerr << "usage: " << argv[0]
+		<< " reconstruct <moments.chebmom2D> <bastin|greenwood> <broadening_meV>\n"; return 2; }
+	const std::string momfile = argv[2];
+	const std::string which   = argv[3];
+	const double broadening   = std::stod(argv[4]);
+
+	const lsquant::KuboObservable* obs = 0;
+	std::string tag;
+	if      (which == "bastin")    { obs = &lsquant::KUBO_BASTIN;    tag = "KuboBastin_"; }
+	else if (which == "greenwood") { obs = &lsquant::KUBO_GREENWOOD; tag = "KuboGreenWood_"; }
+	else { std::cerr << "reconstruct: formula must be 'bastin' or 'greenwood'\n"; return 2; }
+
+	chebyshev::Moments2D mu(momfile.c_str());
+	mu.ApplyJacksonKernel(broadening, broadening);
+	const std::vector<std::pair<double,double> > data = lsquant::reconstruct_kubo(mu, *obs);
+
+	const std::string outputName = tag + mu.SystemLabel() + "JACKSON.dat";
+	std::cout << "Saving the data in " << outputName << std::endl;
+	std::ofstream f(outputName.c_str());
+	for (size_t i = 0; i < data.size(); ++i) f << data[i].first << " " << data[i].second << std::endl;
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	if (argc < 2) return usage(argv[0]);
+	const std::string cmd = argv[1];
+	if (cmd == "inspect")
+	{
+		if (argc < 3) { std::cerr << "usage: " << argv[0] << " inspect <run.json | operator.desc>\n"; return 2; }
+		return lsquant::inspect_path(argv[2]);
+	}
+	if (cmd == "reconstruct") return cmd_reconstruct(argc, argv);
+	if (cmd == "--help" || cmd == "-h" || cmd == "help") { usage(argv[0]); return 0; }
+	std::cerr << "lsquant: unknown command '" << cmd << "'\n\n";
+	return usage(argv[0]);
+}

--- a/src/lsquant_inspect.cpp
+++ b/src/lsquant_inspect.cpp
@@ -1,72 +1,10 @@
-// lsquant inspect -- print what a run.json (and an operator .desc) will actually do, including
-// the resolved NUMERICAL PROVENANCE (alpha, bounds source, hbar/units, kernel). Replaces having
-// to read positional argv and decode filename metadata to understand a run.
-//
-// Usage:
-//   lsquant_inspect <run.json>            inspect a run config
-//   lsquant_inspect <operator.desc>       inspect an operator descriptor
+// Standalone `lsquant_inspect` (kept for compatibility; the `lsquant inspect` subcommand shares
+// the same lsquant::inspect_path). Phase 7.
 #include <iostream>
-#include <fstream>
 #include <string>
-#include "run_config.hpp"
-#include "operator_descriptor.hpp"
-#include "units.hpp"
-#include "recon_grid.hpp"
-
-static bool ends_with(const std::string& s, const std::string& suf) {
-    return s.size() >= suf.size() && s.compare(s.size()-suf.size(), suf.size(), suf) == 0;
-}
-static bool file_exists(const std::string& p) { std::ifstream f(p.c_str()); return f.good(); }
-
-static void inspect_desc(const std::string& path) {
-    lsquant::OperatorDescriptor d = lsquant::read_descriptor(path);
-    std::cout << "operator descriptor: " << path << "\n";
-    if (!d.valid) { std::cout << "  (could not parse)\n"; return; }
-    std::cout << "  observable : " << d.observable << "\n"
-              << "  component  : " << (d.component.empty() ? "(none)" : d.component) << "\n"
-              << "  units      : " << d.units << "\n"
-              << "  provenance : " << d.provenance << "\n";
-    if (d.has_bounds) std::cout << "  bounds(a,b): [" << d.a << ", " << d.b << "]\n";
-    if (d.has_basis)  { std::cout << "  basis      : " << d.orbitals_per_cell << " orbitals/cell x "
-                                  << d.num_cells << " cells, spins "; for (int s:d.orbital_spin) std::cout<<(s>0?'+':'-'); std::cout<<"\n"; }
-}
-
-static void inspect_run(const std::string& path) {
-    lsquant::RunConfig c = lsquant::read_run_config(path);
-    std::cout << "run config: " << path << "\n";
-    if (!c.valid) { std::cout << "  INVALID: " << c.error << "\n"; return; }
-
-    const std::string ham_desc = "operators/" + c.label + ".HAM.desc";
-    const std::string bounds_src =
-        file_exists("BOUNDS")  ? "BOUNDS file (explicit override)" :
-        file_exists(ham_desc)  ? ("descriptor " + ham_desc + " (producer Lanczos)") :
-                                 "Gershgorin enclosure + pad (fallback)";
-    // alpha: run.json value if set, else the recon_grid default/env
-    const double alpha = (c.alpha >= 0.0) ? c.alpha : chebyshev::safety_factors().recon_cutoff;
-
-    std::cout << "  what runs   : <" << c.operator_left << "|.|" << c.operator_right
-              << "> correlation on '" << c.label << "', M = " << c.num_moments << "\n"
-              << "  state       : " << c.state << "\n"
-              << "  kernel      : " << c.kernel;
-    if (c.kernel == "lorentz") std::cout << " (lambda = " << c.lambda << ")";
-    std::cout << "\n";
-    std::cout << "  -- numerical provenance --\n"
-              << "  recon alpha : " << alpha << (c.alpha>=0.0 ? " (from run.json)" : " (recon_grid default/env)") << "\n"
-              << "  bounds pad  : " << chebyshev::safety_factors().bounds_pad << "\n"
-              << "  bounds from : " << bounds_src << "\n"
-              << "  hbar (units): " << chebyshev::HBAR << " eV*fs\n";
-    if (file_exists(ham_desc)) { std::cout << "  -- Hamiltonian descriptor --\n"; inspect_desc(ham_desc); }
-    std::cout << "  output      : "
-              << (c.output.empty() ? "(derived from run parameters)" : c.output) << "\n";
-}
+#include "inspect.hpp"
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "usage: " << argv[0] << " <run.json | operator.desc>\n";
-        return 2;
-    }
-    const std::string path = argv[1];
-    if (ends_with(path, ".desc")) inspect_desc(path);
-    else                          inspect_run(path);
-    return 0;
+    if (argc < 2) { std::cerr << "usage: " << argv[0] << " <run.json | operator.desc>\n"; return 2; }
+    return lsquant::inspect_path(argv[1]);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -213,3 +213,9 @@ add_test(NAME fft_grid_regression
 add_executable(phase6_scaffolding_test phase6_scaffolding_test.cpp)
 target_include_directories(phase6_scaffolding_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME phase6_scaffolding COMMAND phase6_scaffolding_test)
+
+# --- single lsquant dispatcher binary (Phase 7) ---------------------------------
+# `lsquant <command>` subsumes the library-ized tasks: reconstruct (byte-identical to the legacy
+# inline_kubo* drivers) and inspect (shared lsquant::inspect_path with the standalone binary).
+add_test(NAME single_binary
+         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/single_binary.sh ${CMAKE_BINARY_DIR})

--- a/test/single_binary.sh
+++ b/test/single_binary.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Phase 7 -- the single `lsquant` dispatcher binary.
+#
+# Asserts the dispatcher subcommands match the legacy path:
+#   (1) `lsquant reconstruct ... bastin|greenwood` is BYTE-IDENTICAL to the legacy
+#       inline_kuboBastin/Greenwood drivers (same unified routine, one binary);
+#   (2) `lsquant inspect run.json` reports the run; and the standalone lsquant_inspect (thin
+#       wrapper sharing lsquant::inspect_path) gives the SAME output.
+#
+# Usage: single_binary.sh <BUILD_DIR>
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD="$(cd "${1:-$REPO/build}" && pwd)"
+LSQ="$BUILD/lsquant"
+GMOM="$REPO/test/golden/NonEqOpVX-VXgraphene_goldenKPM_M64x64_statedefault.chebmom2D"
+
+[ -x "$LSQ" ] || { echo "FAIL: lsquant dispatcher missing"; exit 1; }
+[ -f "$GMOM" ] || { echo "FAIL: graphene moments missing"; exit 1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+cp "$GMOM" "$T/"
+( cd "$T"
+  M="$(ls *.chebmom2D | head -1)"
+
+  # (1) reconstruct == legacy, byte-for-byte
+  "$BUILD/inline_kuboBastinFromChebmom" "$M" 10 >/dev/null 2>&1;  mv KuboBastin_*JACKSON.dat legacy_b.dat
+  "$LSQ" reconstruct "$M" bastin 10 >/dev/null 2>&1;             mv KuboBastin_*JACKSON.dat disp_b.dat
+  diff -q legacy_b.dat disp_b.dat >/dev/null \
+    && echo "PASS(reconstruct/bastin): lsquant == legacy driver byte-for-byte" \
+    || { echo "FAIL: lsquant reconstruct bastin differs from legacy"; exit 1; }
+
+  "$BUILD/inline_kuboGreenwoodFromChebmom" "$M" 10 >/dev/null 2>&1; mv KuboGreenWood_*JACKSON.dat legacy_g.dat
+  "$LSQ" reconstruct "$M" greenwood 10 >/dev/null 2>&1;            mv KuboGreenWood_*JACKSON.dat disp_g.dat
+  diff -q legacy_g.dat disp_g.dat >/dev/null \
+    && echo "PASS(reconstruct/greenwood): lsquant == legacy driver byte-for-byte" \
+    || { echo "FAIL: lsquant reconstruct greenwood differs from legacy"; exit 1; }
+
+  # (2) inspect via dispatcher == standalone lsquant_inspect
+  printf '{ "label":"graphene_golden", "operator_left":"VX", "operator_right":"VX", "num_moments":64 }\n' > run.json
+  "$LSQ" inspect run.json > insp_dispatch.txt 2>&1
+  grep -q "M = 64" insp_dispatch.txt || { echo "FAIL: lsquant inspect missing run info"; exit 1; }
+  echo "PASS(inspect): lsquant inspect reports the run"
+  if [ -x "$BUILD/lsquant_inspect" ]; then
+    "$BUILD/lsquant_inspect" run.json > insp_standalone.txt 2>&1
+    diff -q insp_dispatch.txt insp_standalone.txt >/dev/null \
+      && echo "PASS(inspect-share): dispatcher and standalone share lsquant::inspect_path" \
+      || { echo "FAIL: dispatcher inspect != standalone inspect"; exit 1; }
+  fi
+)
+echo "PASS: single lsquant binary subsumes reconstruct + inspect (byte-identical to legacy)"


### PR DESCRIPTION
## Summary
Starts Phase 7 — collapsing the 41 per-task `main()`s into one `lsquant` binary with subcommands.
Strangler-fig: the new binary grows **beside** the legacy drivers (which still build); it subsumes
the tasks the refactor has already library-ized. **ctest 21/21.**

### What landed
- **`include/inspect.hpp` + `src/inspect.cpp`** — `lsquant::inspect_path` moved into the library;
  `lsquant_inspect` is now a thin wrapper (byte-identical output).
- **`src/lsquant.cpp`** — `lsquant <command> [args]`:
  - `inspect <run.json|.desc>` → `lsquant::inspect_path`
  - `reconstruct <moments.chebmom2D> <bastin|greenwood> <broadening>` → `reconstruct_kubo`
- **`single_binary` test** — `lsquant reconstruct` is **byte-identical** to
  `inline_kuboBastin/Greenwood`; `lsquant inspect` == standalone `lsquant_inspect`.

### Scope note
The "models as `HamiltonianOp` plugins" half of Phase 7 depends on the **deferred Phase-6**
migration, so this slice does the **dispatcher consolidation** (independent of it). `compute` and
folding the remaining drivers into subcommands follow. No 🔒 — merging per the standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)