### PR TITLE
Add agent instructions and templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,172 @@
+# AGENTS.md — agent operating contract (project-agnostic)
+
+This file defines how an agent **behaves**, not what any one project contains.
+Drop the same file into every repo; per-project facts live in that repo's own
+context doc (see §1), never here. Auto-read by Claude Code; symlink
+`CLAUDE.md -> AGENTS.md` and point other agents (Kimi, etc.) at it explicitly.
+**Read it fully before acting.**
+
+---
+
+## §0 — Session preamble (run first, every session)
+
+You operate **in place** inside an existing checkout — do not clone elsewhere.
+Verify the working tree is the right one and not stale, then read context (§1).
+
+```bash
+git rev-parse --is-inside-work-tree            # must print: true
+git remote get-url origin                      # must match the remote in the project context doc
+git rev-parse --abbrev-ref HEAD                # branch
+git rev-parse HEAD                             # HEAD — record it in the PR body
+git fetch --quiet origin
+git rev-list --left-right --count HEAD...@{u}  # right number = commits behind upstream
+```
+
+If the remote is not the expected one, or you are behind upstream, **stop and
+report** before doing anything. (Past failure: an agent worked in a stale clone
+of a *renamed/old* remote and declared the plan "fiction.")
+
+---
+
+## §1 — Read project context before assuming anything
+
+Do not reconstruct state from the diff. Read the project's context docs first;
+they are the source of truth for all project facts (backends, placeholders,
+conventions, banned files, phases). On conflict: **this file governs behavior,
+the project docs govern facts.** A missing doc → say so, don't invent state.
+
+Expect **one living doc per role**, not a pile of overlapping handoffs:
+
+| Role | Holds | When |
+|------|-------|------|
+| Orient | build/run + repo map | once, for bearings |
+| **State** | current phase · invariants · open items; dated + `verified @ <HEAD>` | **first, every session** |
+| Plan | phased plan + STOP conditions (committed, not local-only) | before starting a phase |
+| Reference | domain conventions / closed forms / oracle | before any domain change |
+| Tests | living gate: green vs pending, target numbers | before & after changes |
+| Plotting | figure specs: widths · fonts · palette · caption format | before producing any figure |
+
+**Anti-rot:** the State doc must carry `verified against HEAD <hash> on <date>`.
+If that hash is behind the §0 HEAD, treat the State doc as **possibly stale** —
+reconcile or flag before trusting its invariants. Point-in-time discovery notes
+and superseded docs go in an archive dir, never the read-first set.
+
+---
+
+## §2 — Language, communication, and documentation
+
+- Write **everything in English**: PR bodies, commit messages, code comments,
+  docstrings, docs. (The maintainer may converse in another language; agent
+  output is English regardless.)
+- **Templates (match them; never invent a structure when one exists):**
+  - Communications / tutorials → `agents_templates/tutorial_*`
+  - In-code comments / PR text → `agents_templates/documentation_*`
+  - If a referenced template is absent, flag it rather than guessing.
+- **Documentation = in-code comments by default.** They are the source an
+  automated generator (Doxygen for C++, Sphinx/NumPy-style for Python) can later
+  turn into rendered docs.
+  - **Do not run a doc generator or emit generated/rendered docs at any stage
+    unless explicitly requested.** When explicitly requested, read both
+    `documentation_*` templates first and follow them.
+  - When not requested, the in-code comments you write must be an **extensive,
+    problem-oriented description** of the code: the problem solved, the approach,
+    assumptions, units/conventions, complexity — not a line-by-line restatement.
+  - Always include, where applicable: **Pitfall**, **To-do**, **Warning**.
+
+---
+
+## §3 — Change discipline
+
+- **Coverage before change.** If the project has a regression / golden / oracle
+  suite, never refactor a path that lacks coverage — add coverage first. A
+  refactor step without a safety net is unsafe.
+- **Green before commit.** Run the full suite (with any fixed seed the project
+  specifies) before every commit; state the pass count in the PR body. Keep
+  exact-match goldens byte-identical unless the change is explicitly intended to
+  move them, and then justify it.
+- **No generated or bulk artifacts.** No build caches, no large binaries, no
+  data blobs above the project's size threshold. If you find committed cruft of
+  this kind, propose removing and gitignoring it — don't add more.
+- **Respect placeholders.** Intentional throwing stubs / not-implemented guards
+  stay as they are unless the task is to implement them. Don't silently revive
+  or re-stub them.
+
+---
+
+## §4 — PR and merge-commit contract
+
+The durable record lives in the **squash-merge commit body**, not only the
+GitHub PR UI (PR text can be rate-limited or unreachable; `git log` is forever).
+Every PR body **and** the squash-merge message must contain all four:
+
+1. **Why these files changed** — per file or logical group, the *reason*, not the
+   *what* (the diff shows what).
+2. **Tests** — which targets ran, the seed, the pass count, and confirmation that
+   exact-match goldens stayed byte-identical. Name any new gate added.
+3. **Reason for acceptance** — why this is safe to merge now (behavior-preserving?
+   covered? gated?), tied to a project invariant (§1) or a plan phase.
+4. **To-do / follow-ups** — what this PR deliberately leaves open and what it
+   unblocks. Note any placeholder touched.
+
+Record the HEAD hash from §0 and the relevant commit hashes.
+
+---
+
+## §5 — Reference material (mild RAG, never committed)
+
+Reference books/papers live in `agent_references/` — **gitignored, local only.**
+Only the manifest `agent_references.md` is committed; it carries title + topics +
+a "use-for" tag per entry so you can grep it to pick what to open. Never
+`git add` a reference file; never paste its content into the repo. When a change
+needs a literature justification, grep the manifest by topic, open only the
+matching local file, and cite it in the PR body by title.
+
+`.gitignore`:  `agent_references/`
+
+Manifest entry format (`agent_references.md`):
+```
+## <Author, Venue Year> — <Title>
+- file:    agent_references/<filename>   (local only, not committed)
+- topics:  <semicolon-separated topics>
+- use-for: <when an agent should reach for this>
+```
+
+---
+
+## §6 — Definition of done
+
+§0 verification recorded · full suite green at the project's fixed seed with
+goldens byte-identical · PR body + squash-merge message satisfy all four points
+of §4 · no banned artifacts committed (§3, §5) · output in English (§2) ·
+project context doc / plan updated if the change advances a phase.
+
+## §7 — Figures and plots
+
+Behavior here; the **specifications** (column widths, fonts, palette, encoding,
+caption format) live in the project's `plotting_style.md`, a Reference-role doc
+(§1). On conflict: this section governs *when/how you act*, the style doc governs
+*the numbers*.
+
+- **Trigger.** Any figure you generate or edit, for any surface — article,
+  GitHub Pages, slides, README. No exceptions for "quick" or "throwaway" plots.
+- **Read the style doc first.** Before producing a figure, read the project's
+  `plotting_style.md` and use its presets. Missing doc → **say so, don't invent
+  defaults** (§1). Do not reconstruct style from existing figures.
+- **Figure source is code, not raster.** Commit the generating script; rendered
+  figures are regenerable cache. Do not commit rasters above the project size
+  threshold or any bulk image blob (§3, §5). Export final-size artifacts only
+  where the project explicitly collects them.
+- **No title; the caption carries everything.** Never set a figure/panel title.
+  Every figure ships **with** a self-contained caption (begins `FIG. N.`, defines
+  each colour/linestyle/marker, and lists the parameters needed to reproduce the
+  panel). **A figure delivered without its caption is not done** — emit the
+  caption in the `.tex`, the PR body, or a sidecar per the style doc.
+- **Redundant encoding is mandatory.** Traces separable by colour **and**
+  linestyle **and** marker; legible in grayscale and under colour-vision
+  deficiency. Colour-only encoding, `jet`/rainbow, and sole red–green contrast
+  are rejected.
+- **Self-check gate.** Run the style doc's acceptance checklist and report
+  PASS/FAIL in the PR body next to the test gate (§3, §4). Any failed box →
+  not shipped. Treat a non-compliant figure like a red suite: fix or escalate.
+- **No post-export rescaling.** Export at the target width and include at natural
+  size; rescaling on `\includegraphics` breaks the lettering-height rule.

--- a/agent_template/documentation_STYLE_GUIDE.md
+++ b/agent_template/documentation_STYLE_GUIDE.md
@@ -1,0 +1,181 @@
+# How to document LinQT code
+
+This guide explains how to turn `DOCSTRING_TEMPLATE.md` into finished in-code
+documentation, and it is opinionated about voice on purpose, in the same spirit
+as the tutorial guide. "Documentation" here means the comments that live inside
+the source: docstrings in Python, Doxygen blocks in C and C++. It is not the
+rendered website. Read a well documented module in the codebase, then read this.
+
+## The voice
+
+Write the documentation as if you were explaining to a competent colleague who
+will call your code tomorrow and has never seen it, in the spirit of Sagan,
+Feynman, or Tyson. That is not decoration. It is a discipline with consequences
+for every block you write.
+
+Lead with the problem, not the mechanism. The first paragraph after the summary
+says what computational or physical problem this unit solves and why it exists,
+before a single parameter is named. "Given a sparse Hamiltonian, estimate the
+spectral density by a stochastic trace over Chebyshev moments" earns attention.
+"This function takes `H`, `M`, and `n_states` and returns an array" does not.
+
+Carry one responsibility. A docstring documents one unit doing one thing. If you
+cannot state that thing in a single summary line, the unit is doing too much,
+and the fix is in the code, not in longer prose.
+
+Earn the block; never restate the signature. The reader can already see
+`def dos(H, M)`. The documentation earns its place by saying what `H` and `M`
+mean physically, in what units, with what shape and sign convention, and why the
+function exists. Types and names that introspection already exposes are not
+content.
+
+Respect the reader's expertise, and only theirs. Assume a programmer fluent in
+the language. Do not explain a list comprehension, a pointer, or what a trace
+is. Do explain anything that steps outside that vocabulary: the physics, the
+provenance of the algorithm, the units, the broadening, the storage order.
+Define a domain term the first time it earns its place.
+
+Trust the code to be legible. Compact documentation reads as confidence. Do not
+narrate the implementation line by line; the source is right there. Document the
+contract and the traps, not the control flow.
+
+Name the trap. The most useful sentence is often the one that stops a competent
+caller from the obvious misuse: the array that must be C-contiguous, the energy
+that is in Rydberg and not eV, the routine that mutates its input in place, the
+estimator whose variance grows when the moment count is too low. Find that
+sentence for your unit and give it a warning block.
+
+## What the generator does, and when
+
+There are two layers, and they are not the same task.
+
+Layer one is the in-code documentation: the docstrings and Doxygen blocks this
+guide is about. Writing them is part of writing the code. They are always
+present.
+
+Layer two is the rendered output: the HTML or PDF that Sphinx (with numpydoc)
+or Doxygen builds from layer one. This is a separate, explicit action.
+
+The rule: always write layer one. Never produce layer two on your own
+initiative. Do not create `conf.py`, a `Doxyfile`, a `docs/` build tree, or run
+`sphinx-build` or `doxygen` unless a task asks for the rendered documentation in
+words. When the task does not say otherwise, the deliverable is source whose
+in-code documentation is complete, not a generated site.
+
+Default depth, when nothing else is specified: every public unit gets an
+extensive, problem-oriented description. The extended summary is where that
+description lives. Terse one-liners are for genuinely obvious units only, and
+only when the task asks for brevity.
+
+## Hard rules
+
+These are not stylistic preferences. Apply them without exception.
+
+- Python follows PEP 8 for layout and PEP 257 for docstring conventions. The
+  docstring body uses the numpydoc section format (Sphinx reads it through the
+  numpydoc or napoleon extension). C and C++ use Doxygen blocks in Javadoc
+  style: `/** ... */` with `@command`. Pick one comment convention per language
+  and never mix it within a project.
+- The summary line is one line, in the imperative mood, ends with a period, fits
+  on the line, and does not restate the signature. "Estimate the density of
+  states.", not "Estimates the DOS by taking H, M and returning an array."
+- All mathematics is LaTeX. In Python docstrings use `` :math:`...` `` inline and
+  a `.. math::` directive for displayed equations. In Doxygen use `\f$ ... \f$`
+  inline and `\f[ ... \f]` displayed. Never write equations as ASCII in prose.
+- No em dashes anywhere. Use a comma, a colon, parentheses, or a full stop.
+- Document the contract, not the implementation. Parameters, returns, raised
+  errors, units, array shapes, ownership, and side effects belong in the
+  documentation. Implementation detail the caller does not need goes in `Notes`
+  or `@details`, never in the summary.
+- Every public symbol is documented: the module or file, every public function,
+  class, method, and any module-level constant whose meaning is not obvious.
+  Private helpers (leading underscore in Python, `static` or internal in C) get
+  documentation only where the reason for their existence is non-obvious.
+- Keep documentation lines within the project line length. numpydoc targets 75
+  characters for terminal readability; if the project sets nothing, use PEP 8
+  (79 for code, 72 for flowing text in docstrings and comments). State the limit
+  once and hold it.
+- Minimal formatting. The numpydoc section underlines (`-----`) and the Doxygen
+  command markers are the only structure you need. No decorative banners, no
+  ASCII separators, no bold scattered through prose.
+
+## Pitfalls, TODOs, and warnings
+
+Each kind of hazard has one home, so a reader scanning for danger finds it in
+the same place every time, and so the generator can collect the machine-readable
+ones into their own lists.
+
+- A pitfall the caller must know to use the unit correctly goes in a `Warnings`
+  section (numpydoc free text, distinct from `Warns`, which lists the
+  `warnings.warn` categories the unit may raise) or a `@warning` block in
+  Doxygen. Examples: not thread safe, mutates its argument, requires a
+  contiguous array, energies in Rydberg.
+- An unfinished piece of work is an inline `# TODO(owner): ...` in Python or a
+  `@todo` in Doxygen. Tie each to an issue and an owner; a bare `# TODO` with no
+  owner is noise.
+- A known defect is `@bug` in Doxygen; in Python state it in `Warnings` and tag
+  the offending line `# FIXME(owner): ...`. Both should reference a filed issue.
+- A useful remark that is not a hazard goes in `Notes` or `@note`.
+- On the C side, a precondition, postcondition, or invariant goes in `@pre`,
+  `@post`, or `@invariant`. In Python state it in the extended summary, or in
+  `Raises` if violating it raises.
+
+One rule of phrasing for warnings: state the consequence first, then the
+condition. "Returns garbage if `H` is not Hermitian" beats "If `H` is not
+Hermitian, then ...". The reader scanning for what can break should learn the
+cost in the first clause.
+
+## Structure of a documentation block
+
+The shape is fixed because it works, and numpydoc prescribes the section set and
+order, so do not invent sections.
+
+1. Summary line. The single responsibility, imperative, one line.
+2. Extended summary. The problem-oriented description: the problem solved, the
+   physics or algorithm, its provenance, and the conventions (units, sign,
+   shape, storage order). This is the part that is extensive by default.
+3. The contract. `Parameters` / `@param`, `Returns` / `@return` (plus `@retval`
+   for status codes), `Yields`, and the error conditions in `Raises`, with type
+   and shape stated.
+4. Hazards and notes. `Warnings` / `@warning`, `Notes` / `@note`, and on the C
+   side `@pre`, `@post`, `@invariant`.
+5. Cross references. `See Also` / `@see` to the related units a reader will want
+   next.
+6. References. `References` / `@cite` for the one equation or paper the unit
+   implements. Cite the source the way the tutorial guide cites a method: the
+   single reference the code rests on, not a bibliography.
+7. Examples. `Examples` / `@code`, written as doctests where they can run.
+
+The module or file header carries its own block. A Python module docstring says
+what the module is for in terms of the objects it provides. Every C and C++ `.c`
+and `.h` file opens with a `@file` and a `@brief`; without them Doxygen will not
+emit documentation for the file's globals.
+
+## Naming, so callers can trust the contract
+
+Keep the parameter names in the documentation identical to the signature, letter
+for letter. Keep unit names, symbol names, and shape conventions consistent with
+the papers the code implements and consistent across modules, so a reader who
+learned them in one function reads the next without relearning. When you document
+a new unit in an existing module, match the section set the module already uses
+rather than inventing a new one.
+
+## Before you commit
+
+A finished documentation pass passes all of these:
+
+- Every public symbol has a block whose summary is one imperative line, ending
+  in a period, that does not restate the signature.
+- The extended summary states the problem the code solves, with units, sign, and
+  shape conventions, not a walk through the implementation.
+- Every parameter, return value, and raised error is documented, and the names
+  match the signature exactly.
+- Every pitfall is in a `Warnings` or `@warning` block, consequence first; every
+  TODO has an owner and an issue; every known defect is `@bug` or `FIXME`.
+- All mathematics is LaTeX (`` :math:`` ``/`.. math::` or `\f$`/`\f[`), no ASCII
+  math, and there are no em dashes.
+- Python passes `pydocstyle` or `ruff` for PEP 257 and `pycodestyle` or `ruff`
+  for PEP 8, and the numpydoc sections are valid and in the prescribed order.
+  C and C++ produce no Doxygen warnings.
+- The rendered documentation was not built, because no task asked for it.
+- Nothing repeats, and nothing documents what introspection already shows.

--- a/agent_template/documentation_TEMPLATE.md
+++ b/agent_template/documentation_TEMPLATE.md
@@ -1,0 +1,218 @@
+<!--
+  LinQT in-code documentation template.
+  Copy the skeleton for your language into your source file and fill the
+  [[ ... ]] slots. The <!-- ... --> comments are guidance for the author; they
+  never reach the reader, so delete them or leave them in this file.
+
+  Read DOCSTRING_STYLE_GUIDE.md once before writing. The short version:
+    - lead with the problem, earn the block, never restate the signature
+    - one responsibility per unit; extensive problem-oriented extended summary
+    - Python: PEP 8 + PEP 257, numpydoc sections; C/C++: Doxygen, Javadoc style
+    - all math in LaTeX, no em dashes
+    - pitfalls in Warnings/@warning (consequence first), TODOs owned, bugs filed
+    - write the in-code docs; never build the rendered site unless asked
+-->
+
+# Documentation template
+
+This file holds one fillable skeleton per language. Copy the relevant one, fill
+the `[[ ... ]]` slots, and delete the slots that do not apply.
+
+## Python (PEP 257 + numpydoc)
+
+### Module
+
+<!--
+  The module docstring is the first statement in the file. It says what the
+  module is for in terms of the objects it provides, not how they are built.
+  Triple double quotes; summary line on its own; closing quotes on their own
+  line.
+-->
+
+```python
+"""[[One imperative line naming what this module provides.]]
+
+[[Extended summary: the problem this module addresses and the physical or
+computational objects it exposes. Name the conventions that hold module wide
+(units, sign, storage order) so each function does not repeat them.]]
+
+Notes
+-----
+[[Optional: provenance, the paper or method the module implements, in LaTeX
+where there is math, e.g. the moments :math:`\\mu_m = \\mathrm{Tr}\\,T_m(H)`.]]
+"""
+```
+
+### Function
+
+<!--
+  Summary in the imperative, ending with a period, not a restatement of the
+  signature. Then the problem-oriented extended summary. numpydoc section order
+  is fixed: Parameters, Returns (or Yields), Raises, Warns, Warnings, See Also,
+  Notes, References, Examples. Use only the sections you need, in that order.
+-->
+
+```python
+def [[name]]([[args]]):
+    r"""[[Imperative one-line summary of the single responsibility.]]
+
+    [[Extended summary: the problem this solves and why it exists. State the
+    physics or algorithm and the conventions. Put math in LaTeX, e.g.
+
+    .. math:: \rho(E) = \sum_n \delta(E - E_n).
+    ]]
+
+    Parameters
+    ----------
+    [[name]] : [[type, with shape if an array, e.g. ndarray of shape (n, n)]]
+        [[What it means physically and its units. Not just its type.]]
+    [[name]] : [[type]], optional
+        [[Meaning and the default's effect.]]
+
+    Returns
+    -------
+    [[name]] : [[type and shape]]
+        [[What the value represents physically and its units.]]
+
+    Raises
+    ------
+    [[ExceptionType]]
+        [[The condition that triggers it, consequence first.]]
+
+    Warnings
+    --------
+    [[The pitfall a caller must know, consequence first: e.g. "Returns
+    garbage if `H` is not Hermitian; the routine does not check."]]
+
+    Notes
+    -----
+    [[Optional: derivation, complexity, or a subtlety that would otherwise be
+    misread. The sentence that stops the obvious wrong conclusion lives here.]]
+
+    References
+    ----------
+    [[The one method paper the unit implements, e.g. A. Weisse et al.,
+    Rev. Mod. Phys. 78, 275 (2006).]]
+
+    Examples
+    --------
+    >>> [[a runnable doctest that shows the intended call and result]]
+    """
+    # TODO([[owner]]): [[unfinished work, tied to issue #NNN]]  # remove if none
+    [[...]]
+```
+
+### Class
+
+<!--
+  Document the class for the role it plays. Document each public method with its
+  own function-style docstring. Attributes the caller reads or sets go in an
+  Attributes section.
+-->
+
+```python
+class [[Name]]:
+    """[[Imperative one-line summary of the role this type plays.]]
+
+    [[Extended summary: the problem this type models and the invariant it
+    maintains across its methods.]]
+
+    Parameters
+    ----------
+    [[name]] : [[type]]
+        [[Constructor argument: meaning and units.]]
+
+    Attributes
+    ----------
+    [[name]] : [[type]]
+        [[A public attribute the caller may read; meaning and units.]]
+
+    Warnings
+    --------
+    [[A type-wide hazard, e.g. "Instances are not thread safe; do not share one
+    across workers."]]
+    """
+```
+
+## C and C++ (Doxygen, Javadoc style)
+
+### File header
+
+<!--
+  Every .c, .h, .cpp, and .hpp opens with this. Without @file and @brief,
+  Doxygen will not document the file's global functions, typedefs, or enums.
+  Math in LaTeX with \f$ ... \f$ inline and \f[ ... \f] displayed.
+-->
+
+```c
+/**
+ * @file [[name.h]]
+ * @brief [[One line naming what this file provides.]]
+ *
+ * @details [[The problem this file addresses and the objects it exposes,
+ *           with the conventions (units, sign, storage order) that hold
+ *           across the file. Math in LaTeX, e.g. \f$ H = H^\dagger \f$.]]
+ *
+ * @author  [[name]]
+ */
+```
+
+### Function
+
+<!--
+  @brief is the imperative one-line summary; @details is the problem-oriented
+  description. Use @param[in], @param[out], @param[in,out] to mark direction.
+  @retval documents specific status codes; @return documents the return value.
+  Hazards and contract: @warning (consequence first), @pre, @post, @note.
+-->
+
+```c
+/**
+ * @brief [[Imperative one-line summary of the single responsibility.]]
+ *
+ * @details [[The problem this solves and why it exists, with the algorithm and
+ *           its conventions. Displayed math in LaTeX:
+ *           \f[ \mu_m = \mathrm{Tr}\, T_m(H). \f] ]]
+ *
+ * @param[in]     [[name]] [[Meaning and units, with array length if a pointer.]]
+ * @param[out]    [[name]] [[What the routine writes here and its units.]]
+ * @param[in,out] [[name]] [[State on entry and on exit.]]
+ *
+ * @return [[What the return value represents.]]
+ * @retval [[CODE]] [[The condition that yields this status code.]]
+ *
+ * @pre  [[A precondition the caller must satisfy, e.g. n > 0.]]
+ * @post [[A guarantee that holds on success.]]
+ *
+ * @warning [[The pitfall, consequence first: e.g. "Writes out of bounds if
+ *          `n` exceeds the allocation; the routine does not check."]]
+ * @note    [[A useful remark that is not a hazard.]]
+ *
+ * @todo [[Unfinished work, tied to a filed issue.]]   // remove if none
+ * @bug  [[A known defect, tied to a filed issue.]]    // remove if none
+ *
+ * @see  [[a related function the reader will want next]]
+ */
+[[return_type]] [[name]]([[parameters]]);
+```
+
+### Struct or class
+
+<!--
+  Document the type for the role it plays. Document each member with a trailing
+  /**< ... */ where its meaning is not obvious from the name.
+-->
+
+```c
+/**
+ * @brief [[One line naming the role this type plays.]]
+ *
+ * @details [[The problem this type models and the invariant its fields keep.]]
+ *
+ * @warning [[A type-wide hazard, if any.]]
+ */
+typedef struct {
+    [[type]] [[name]];   /**< [[meaning and units]] */
+    [[type]] [[name]];   /**< [[meaning and units]] */
+} [[Name]];
+```

--- a/agent_template/documentation_incode.md
+++ b/agent_template/documentation_incode.md
@@ -1,0 +1,68 @@
+# documentation_incode — in-code comment template
+
+Scope: **in-code documentation (comments/docstrings)**. These comments are the
+*source* an automated generator (Doxygen for C++ — the project default; Sphinx /
+NumPy-style for Python) can later turn into rendered docs.
+
+## When the generator runs
+- **Default: never.** Do not run a doc generator or emit generated/rendered
+  documentation at any stage **unless explicitly requested.**
+- **When explicitly requested:** read this file and `documentation_pr.md`, then
+  follow them.
+
+## What to write by default (not requested)
+For the code you wrote, write **an extensive, problem-oriented description** as
+in-code comments — describe the *problem* the code solves, the approach taken,
+assumptions, units/conventions, and complexity. Do **not** restate what the code
+literally does line by line. Always include, where applicable: **Pitfall**,
+**To-do**, **Warning**.
+
+## C++ skeleton (Doxygen — matches the existing `@brief` style)
+```cpp
+/**
+ * @brief One-line summary.
+ *
+ * Problem-oriented description: the problem this solves, the chosen approach,
+ * assumptions, units/conventions, complexity. Not a line-by-line restatement.
+ *
+ * @param  x   meaning + units/range
+ * @return     meaning + units
+ *
+ * @warning Hard constraint; violating it is UB / a correctness break.
+ * @par Pitfall
+ *      The subtle gotcha that has bitten (or will bite) a caller here.
+ * @todo Concrete follow-up, ideally tied to a plan phase.
+ */
+```
+> `@par Pitfall` works as-is. To get a first-class `@pitfall` tag, add to the
+> Doxyfile: `ALIASES += pitfall="@par Pitfall:\n"`.
+
+## Python skeleton (NumPy-style docstring)
+```python
+def f(x):
+    """One-line summary.
+
+    Problem-oriented description: the problem solved, the approach, assumptions,
+    units/conventions, complexity. Not a restatement of the code.
+
+    Parameters
+    ----------
+    x : <type>
+        Meaning + units/range.
+
+    Returns
+    -------
+    <type>
+        Meaning + units.
+
+    Warnings
+    --------
+    Hard constraint; violating it breaks correctness.
+
+    Notes
+    -----
+    Pitfall: the subtle gotcha a caller will hit here.
+
+    .. todo:: Concrete follow-up.
+    """
+```

--- a/agent_template/documentation_pr.md
+++ b/agent_template/documentation_pr.md
@@ -1,0 +1,30 @@
+# documentation_pr — PR / merge-commit template
+
+Scope: **PR bodies and squash-merge commit messages.** Canonical source; mirror
+to `.github/pull_request_template.md` so GitHub pre-fills it. Write in English.
+The durable record is the **squash-merge body**, not the GitHub PR UI (PR text
+can be unreachable; `git log` is forever).
+
+## Why these files changed
+<!-- Per file or logical group: the *reason*, not the *what* (the diff shows what). -->
+
+## Tests
+<!-- Targets/gates run · fixed seed (if any) · pass count ·
+     confirm exact-match goldens byte-identical · name any new gate. -->
+
+## Reason for acceptance
+<!-- Why safe to merge now: behavior-preserving? covered? gated?
+     Tie to a project invariant (repo context doc) or a plan phase. -->
+
+## To-do / follow-ups
+<!-- What this PR leaves open and what it unblocks. -->
+
+## Pitfall
+<!-- Subtle gotchas a reviewer or future maintainer must know about this change. -->
+
+## Warning
+<!-- Anything that can break if misused: invariants touched, placeholders, migrations. -->
+
+## Context anchors
+<!-- HEAD hash from the §0 self-check · relevant commit hashes ·
+     any agent_references.md entry cited by title. -->

--- a/agent_template/plotting_style.md
+++ b/agent_template/plotting_style.md
@@ -1,0 +1,152 @@
+# PLOTTING STYLE — AGENT DIRECTIVE (PRL / APS)
+
+**Status: MANDATORY.** Any agent producing a figure for this project MUST comply
+with every rule below and MUST run the self-check in §8 before declaring a figure
+done. Rules marked **[HARD]** come from APS *Information for Contributors* and are
+not negotiable. Rules marked **[HOUSE]** are project conventions.
+
+The reference implementation is `prl_style.py` (presets `single` / `double` /
+`web`). Agents SHOULD import it rather than re-deriving rcParams. Re-deriving is
+allowed only if every value below is reproduced exactly.
+
+---
+
+## 1. Geometry — fix width by destination, never by eye
+
+| Target  | Width        | Source |
+|---------|--------------|--------|
+| single-column article | **3.375 in (8.6 cm)** | [HARD] APS column width |
+| double-column article | **7.0 in** (REVTeX full text width) | [HARD] |
+| 1.5 column (only if detail demands) | ~5.0 in | [HARD] allowed exception |
+| web / GitHub Pages | ~6.5 in at screen dpi | [HOUSE] |
+
+- Width is **locked** to the target. Only the **aspect ratio** is free.
+- Default aspect = golden ratio; shorten height to remove empty top/bottom
+  margins (APS: avoid wasted vertical space). **[HARD]**
+- **NEVER** rescale a figure after export. Do **not** write
+  `\includegraphics[width=\columnwidth]{...}` on a figure exported at a
+  different width — that breaks the 2 mm lettering rule (§4). Export at the final
+  size and include at natural size. **[HARD]**
+
+## 2. No title — information lives in the caption
+
+- **NEVER** call `set_title()` / `suptitle()` on a publication figure. **[HARD/HOUSE]**
+- Multi-panel: tag panels `(a) (b) (c) …` **inside** the axes
+  (`ax.text(0.04, 0.90, "(a)", transform=ax.transAxes, fontweight="bold")`),
+  never as titles. **[HOUSE]**
+- All descriptive content goes in the caption (§7).
+
+## 3. Math in LaTeX
+
+- All axis labels, tick formats, legend entries, and annotations use math mode:
+  `r"$E/t$"`, `r"$\rho(E)\,[t^{-1}]$"`, `r"$\eta = 0.25\,t$"`. **[HOUSE]**
+- **Preferred:** `text.usetex=True` with a REVTeX-matching preamble when the
+  environment has `latex` **and** `dvipng` (or `dvisvgm`).
+- **Fallback (no dvipng):** `text.usetex=False`, `mathtext.fontset="cm"`,
+  `font.family="serif"`. Visually equivalent Computer-Modern glyphs.
+- The agent MUST detect which path is available and report which it used.
+
+## 4. Lettering and line/marker weights — the 2 mm rule
+
+- Lettering height on the **final page** ≥ **2 mm** (~5.7 pt). In practice:
+  tick labels ≥ 8 pt, axis labels ≈ 9–10 pt, at the export width. **[HARD]**
+- Line weight ≥ **0.5 pt** final; project default **1.4 pt**. **[HARD]**
+- Marker (symbol) size ≥ **2 mm**; project default **5 pt**. Avoid small open
+  symbols that fill in on reproduction. **[HARD]**
+- Ticks: inward, on all four sides; minor ticks on. **[HOUSE]**
+
+## 5. Grayscale + colour-vision-deficiency: REDUNDANT ENCODING
+
+Every distinct trace MUST be separable by **at least two** of the following, and
+in practice all three: **[HARD principle, HOUSE implementation]**
+
+1. **Colour** — Okabe-Ito palette only, ordered light→dark so it also separates
+   in grayscale:
+   `#0072B2 #D55E00 #009E73 #CC79A7 #E69F00 #56B4E9 #000000`
+2. **Linestyle** — `- -- -. :` then custom dashes.
+3. **Marker** — `o s ^ D v P X`, with **`markevery`** set so markers are sparse
+   (mandatory on dense/analytic curves; markers may be dropped entirely if
+   linestyle alone disambiguates).
+
+Forbidden: encoding traces by colour **only**; rainbow/`jet`; red+green as the
+sole contrast; fills/hatching too fine to survive 600-dpi reproduction.
+
+## 6. Output
+
+- Raster export at **≥ 600 dpi**; vector (PDF/EPS) preferred for line art. **[HARD]**
+- `bbox_inches="tight"`, small `pad_inches`. White/clear background. **[HARD]**
+- File naming: `fig_<topic>_<target>.{pdf,png}`.
+
+## 7. CAPTION — required, and the figure is incomplete without it
+
+There is no title, so the caption carries **all** interpretive information and
+MUST be self-contained (intelligible without the body text). The agent MUST emit
+the caption alongside the figure (in the `.tex`, the PR description, or a sidecar
+`.caption.txt`). **[HARD + HOUSE]**
+
+A compliant caption MUST:
+
+1. **Begin** with `FIG. N.` — `FIG.` in all caps, the arabic numeral, a period.
+   (REVTeX: use `\caption{...}`; the `FIG. N.` prefix is auto-generated, so write
+   the text after it.) **[HARD]**
+2. Be **one concise paragraph**; a sentence fragment is acceptable.
+3. **Define every visual encoding actually used**: what each colour / linestyle /
+   marker represents (e.g. "solid blue: η = 0.25 t; dashed orange: η = 0.33 t").
+   Never leave a curve unexplained.
+4. State **all units and axes** if not fully obvious from the labels.
+5. State the **physical/numerical parameters** needed to reproduce the panel
+   (system size, broadening, KPM moment count, k-mesh, temperature, disorder
+   realization count, etc.).
+6. Reference **panels by tag**: "(a) …; (b) …".
+7. Put any **cited work** as a normal reference (APS: figure-caption citations go
+   into the reference list, not as inline footnotes).
+8. **No information appears only in a title** (there is none) or only in the body
+   text that the reader needs to read the figure.
+
+### Caption template (fill every slot, delete none silently)
+```
+FIG. N. <one-line statement of what is plotted> as a function of <x quantity>.
+<Per-trace legend in prose: encoding -> meaning, for each trace.>
+<Parameters: system, size, broadening/eta, KPM moments M, k-mesh, T, disorder>.
+(a) <panel a>; (b) <panel b>; ... Units: <if not on axes>. <Method note / Ref [n]>.
+```
+
+### Worked example
+```
+FIG. 2. Local density of states rho(E) of the linear-chain tight-binding model
+versus energy E/t for four Lorentzian broadenings: solid blue eta = 0.25 t,
+dashed orange 0.33 t, dash-dotted green 0.41 t, dotted purple 0.49 t. Curves are
+KPM reconstructions with M = 3000 Chebyshev moments and Jackson kernel on a chain
+of N = 2^20 sites; markers sample every 45th point and carry no extra data.
+```
+
+## 8. SELF-CHECK — run before declaring any figure done
+
+The agent MUST verify and report PASS/FAIL on each:
+
+- [ ] Figure width equals the target column width; not rescaled on inclusion.
+- [ ] No `set_title`/`suptitle`; panels tagged inside axes.
+- [ ] All text is LaTeX/mathtext; usetex-vs-mathtext path reported.
+- [ ] Tick labels ≥ 8 pt and lettering ≥ 2 mm at export size.
+- [ ] Lines ≥ 0.5 pt; markers ≥ 2 mm; `markevery` set on dense curves.
+- [ ] Every trace separable in grayscale AND under deuter/protanopia
+      (Okabe-Ito + linestyle + marker). No colour-only encoding.
+- [ ] Export ≥ 600 dpi (raster) or vector; tight bbox; white background.
+- [ ] A `FIG. N.` caption exists, is self-contained, and defines every encoding
+      and every reproduction parameter (§7 checklist all satisfied).
+
+A figure that fails any box is **not done**. Fix or escalate; do not ship.
+
+## 9. Minimal compliant code pattern
+```python
+from prl_style import prl_context   # presets: 'single' | 'double' | 'web'
+
+with prl_context("single", usetex=False):   # usetex=True if dvipng present
+    fig, ax = plt.subplots()
+    ax.plot(E, rho, label=r"$\eta=0.25\,t$", markevery=55)  # cycle gives style+marker
+    ax.set_xlabel(r"$E/t$")
+    ax.set_ylabel(r"$\rho(E)\,[t^{-1}]$")
+    ax.legend(loc="upper right")          # frameless, set in rcParams
+    fig.savefig("fig_dos_single.pdf")     # 600 dpi / vector, tight bbox
+# Caption emitted separately per §7.
+```

--- a/agent_template/tutorial_style.md
+++ b/agent_template/tutorial_style.md
@@ -1,0 +1,133 @@
+# How to write a LinQT tutorial
+
+This guide explains how to turn `TEMPLATE.md` into a finished tutorial, and it
+is opinionated about voice on purpose. Tutorial 1 (`examples/01_dos_1d_chain`)
+is the worked reference; read it, then read this.
+
+## The voice
+
+Write as if you were explaining the physics to a smart friend who has never met
+the code, in the spirit of Sagan, Feynman, or Tyson. That is not decoration. It
+is a discipline with consequences for every paragraph.
+
+Lead with the phenomenon, not the tool. The reader should feel a small puzzle
+before they ever see a command. "A finite chain has $N$ levels, yet we draw a
+smooth curve; where did the curve come from?" earns attention. "This tutorial
+computes the DOS with `inline_compute-kpm-spectralOp`" does not.
+
+Carry one idea. A tutorial is not a tour of features. It is the unfolding of a
+single physical lesson, and every step exists to advance that one lesson. If a
+step does not move the idea forward, cut it. Tutorial 1 has exactly one spine:
+the moment count is the resolution dial, and finiteness hides in one revival.
+
+Earn every command. No command appears without a physical reason for running it.
+The reader should always know what question the next line answers. The code is
+the answer to a physics question, never the subject.
+
+Respect the reader's expertise, and only theirs. Assume a working physicist who
+programs. Do not explain Chebyshev polynomials or what a trace is. Do explain
+anything that steps outside that vocabulary, and define a term the first time it
+earns its place. Plain language everywhere that is not physics.
+
+Trust the phenomenon to be interesting. You do not need to tell the reader that
+a result is "striking" more than once, and you never need filler. Compact prose
+reads as confidence. Repetition reads as padding.
+
+Name the trap. The most useful sentence in a tutorial is often the one that
+stops a smart reader from drawing the obvious wrong conclusion. In tutorial 1
+that sentence is: while only $\mu_0$ is nonzero, the broadening does nothing,
+because there is nothing above $m=0$ to damp. Find that sentence in your topic
+and give it room.
+
+## Hard rules
+
+These are not stylistic preferences. Apply them without exception.
+
+- All mathematics is LaTeX: `$...$` inline, `$$...$$` for displayed equations.
+  Never write equations as plain ASCII in prose or in code fences.
+- Everything the reader runs goes in a code block. Outputs the reader will refer
+  to (a file name, a header) also go in a plain code block.
+- No em dashes anywhere. Use a comma, a colon, parentheses, or a full stop.
+- No setup paragraphs. Do not write about `PATH`, `LSQUANT_BIN`, `pip install`,
+  build directories, threading, or which language the kernel is in. Installation
+  lives in the main README, and the tutorial points there once, in References.
+- Every figure is embedded with a relative path, and its alt text states the
+  takeaway, not the file name. `![All sizes overlap at the m=0 moment](fig_moments.png)`,
+  not `![figure 2](fig_moments.png)`.
+- Minimal formatting. No bold scattered through prose, no nested bullets. Headings
+  and the occasional short list, nothing more.
+
+## Structure
+
+Follow `TEMPLATE.md`. The shape is fixed because it works:
+
+1. Title as a physical question in plain words.
+2. A two paragraph hook: the puzzle, then what we are after and the one lesson.
+3. `## The physics`: the minimum theory, the closed form to compare against, the
+   one conceptual result stated in words, and an opening figure that shows the
+   problem.
+4. `## Step 1: build ...`: light, the system as physical objects.
+5. `## Step 2: ...`: the kernel call that produces the moments.
+6. `## Step k: <a physical claim>`: later steps are titled with the claim they
+   demonstrate, run a command, embed a figure, read the figure as physics.
+7. `## What to take away`: three to five bullets, each a physics statement.
+8. One sentence forward to the next tutorial.
+9. `## References and links`: the fixed footer below.
+
+Step titles are claims, not verbs. "The moments are intensive" tells the reader
+what they are about to learn. "Plot the moments" tells them nothing.
+
+## Figures
+
+Figures are the argument, so make them carry it.
+
+Ship a small script with each tutorial that produces every embedded PNG, either
+by calling the compiled kernels through `lsqplot.py` or, where the physics has a
+closed form, by computing it directly. The two agree to machine precision when
+the moments come from an exact trace, so a closed-form figure is faithful, not a
+mock-up. Commit the PNGs next to the README so the page renders offline.
+
+Name figures for their content: `fig_levels.png`, `fig_moments.png`,
+`fig_dos.png`. Keep one idea per figure or per panel. A two panel figure should
+make a single comparison the reader can state in one sentence. Put the physical
+parameters the reader needs (the size, the moment count, the broadening) into
+the legend, so the figure is readable on its own.
+
+## Naming, so commands stay copy-pasteable
+
+Keep labels and file patterns consistent across tutorials, because readers paste
+commands and expect the output names to match. Tutorial 1 uses `chain1d_N<N>`
+for the system label, operator label `1` for the identity, and the moment file
+pattern `SpectralOp<op><label>KPM_M<M>_state<state>.chebmom1D`. When you add a
+system, extend the convention rather than inventing a new one.
+
+## References
+
+Every tutorial ends with the same footer, nothing more by default:
+
+```markdown
+## References and links
+
+- LinQT source and documentation: https://github.com/adamecius/lsquant
+- Methodology: Z. Fan, J. H. García, A. W. Cummings et al., *Linear Scaling
+  Quantum Transport Methodologies*, arXiv:1811.07387.
+- Installation: see the main README of the repository.
+```
+
+If, and only if, the tutorial leans on a specific method or result, add a short
+`## Further reading` with that one citation. The KPM kernel paper (Weisse et al.,
+Rev. Mod. Phys. 78, 275, 2006) belongs there when a tutorial uses kernel details.
+Do not build a bibliography. Two or three links is the ceiling.
+
+## Before you commit
+
+A finished tutorial passes all of these:
+
+- A reader could state the one lesson in a single sentence after reading.
+- Every command has a physical reason stated before it.
+- Every equation is LaTeX, every runnable line is in a code block.
+- Every figure is embedded, with alt text that states its takeaway, and the PNG
+  is committed.
+- There are no em dashes and no setup, PATH, pip, or build paragraphs.
+- The references footer is the standard three lines.
+- Nothing repeats, and nothing is there that the lesson does not need.

--- a/agent_template/tutorial_template.md
+++ b/agent_template/tutorial_template.md
@@ -1,0 +1,127 @@
+<!--
+  LinQT tutorial template.
+  Copy this file to examples/NN_short_name/README.md and fill the [[ ... ]] slots.
+  The <!-- ... --> comments are guidance for the author. They are HTML comments,
+  so they stay invisible when the page renders on GitHub. Delete them or leave
+  them; readers never see them.
+
+  Read STYLE_GUIDE.md once before writing. The short version:
+    - lead with the physics, earn every command with a physical reason
+    - one controlling idea per tutorial
+    - all math in LaTeX, all runnable lines in code blocks
+    - no em dashes, no setup or PATH or pip paragraphs
+    - embed every figure; its alt text states the takeaway
+-->
+
+# Tutorial [[N]]: [[the physical question, in plain words]]
+
+<!--
+  THE HOOK. Two short paragraphs, no headings.
+  Paragraph 1: pose the phenomenon as a small puzzle a curious person would feel.
+  Paragraph 2: name what we are after and the single idea this tutorial teaches.
+  Do not mention the tool, the build, or the file formats here. Only the physics.
+-->
+
+[[Open with the phenomenon. Make the reader curious before they meet a command.]]
+
+[[State plainly what we want to compute and the one lesson that will survive into
+later tutorials. End with a sentence of the form "the lesson here is ...".]]
+
+## The physics
+
+<!--
+  The minimum theory needed to read the steps, no more. Define any term that
+  steps outside a working physicist's vocabulary. All equations in LaTeX.
+  Put the ONE conceptual result the tutorial turns on in its own sentence, and
+  say in words why it matters before any code appears.
+-->
+
+[[Define the system and its Hamiltonian.]]
+
+$$ [[ H = \dots ]] $$
+
+[[Give the closed form or known limit we will compare against, in LaTeX.]]
+
+$$ [[ \text{closed form, e.g. } \rho(E) = \dots ]] $$
+
+[[State the key conceptual result of the tutorial and what it means physically.]]
+
+![[[alt text that states the takeaway of this opening figure]]](fig_[[name]].png)
+
+## Step 1: build [[the system]]
+
+<!--
+  Light. One command per size or case. One sentence on what it produces, framed
+  as physical objects (a Hamiltonian, its band edges, a state set), never as a
+  walk through file formats. The reader does not open these files.
+-->
+
+```bash
+[[python make_*.py <args>]]
+```
+
+[[One sentence: what physical objects this writes, and that the next step reads them.]]
+
+## Step 2: [[compute the moments]]
+
+<!--
+  The expensive kernel call. State which operator and why, then the command.
+  Show the one output the reader will refer to. Do not explain threading,
+  C++, or "this is the heavy part".
+-->
+
+[[One sentence naming the operator and the quantity its spectral function gives.]]
+
+```bash
+[[inline_compute-kpm-spectralOp <label> <op> <M> <state>]]
+```
+
+[[One sentence: this evaluates <the trace or estimator>, and writes one file:]]
+
+```
+[[output file name pattern]]
+```
+
+## Step [[k]]: [[a physical statement, not a verb]]
+
+<!--
+  Each later step is titled with a physical claim the step demonstrates, e.g.
+  "the moments are intensive", "resolution follows the moment count". Run a
+  command, embed the figure, then read the figure as physics.
+-->
+
+```bash
+[[python -c "import lsqplot; lsqplot.figure_*( ... )"   or   python lsqplot.py]]
+```
+
+![[[alt text stating what this figure shows]]](fig_[[name]].png)
+
+[[Read the figure: what the curves do, and the physical reason. If there is a
+subtlety the reader would otherwise get wrong, name it plainly here.]]
+
+<!-- Repeat the "Step k" block as needed. Keep the count small. -->
+
+## What to take away
+
+<!-- Three to five bullets. Each is a physics statement, not a software note. -->
+
+- [[the central result, stated as physics]]
+- [[the scaling or invariance lesson]]
+- [[the resolution or accuracy lesson]]
+- [[the provenance or operator lesson, if relevant]]
+
+[[One sentence linking forward: what the next tutorial reuses from this one.]]
+
+## References and links
+
+- LinQT source and documentation: https://github.com/adamecius/lsquant
+- Methodology: Z. Fan, J. H. García, A. W. Cummings et al., *Linear Scaling
+  Quantum Transport Methodologies*, arXiv:1811.07387.
+- Installation: see the main README of the repository.
+
+<!--
+  Optional, only if the tutorial leans on a specific method or result:
+  ## Further reading
+  - [[author, title, venue, year]]
+  e.g. A. Weisse et al., The kernel polynomial method, Rev. Mod. Phys. 78, 275 (2006).
+-->


### PR DESCRIPTION
Adds `AGENTS.md` and the `agent_template/` directory (documentation style guide, templates, in-code/PR docs, plotting style, tutorial style/template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)