### PR TITLE
chore: finish LinQT->LSQUANT rename (comments, CMake LINQT_* flags, planning docs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# LinQT — Linear Quantum Transport (KPM core)
+# LSQUANT — Linear Quantum Transport (KPM core)
 #
 # Reflects the build as it actually is: a single Eigen numeric backend plus
 # FFTW3, GSL and OpenMP. The former INTEL_MKL / EIGEN / BLAS_LIB switches and the
@@ -7,7 +7,7 @@
 # is required:  cmake -B build && cmake --build build -j
 cmake_minimum_required(VERSION 3.16)
 
-project(LinQT VERSION 2.0.0 LANGUAGES CXX)
+project(LSQUANT VERSION 2.0.0 LANGUAGES CXX)
 
 # --- Language / build type ---------------------------------------------------
 set(CMAKE_CXX_STANDARD 11)
@@ -24,8 +24,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
 # --- Options -----------------------------------------------------------------
-option(LINQT_BUILD_UTILITIES   "Build the Python helper utilities" OFF)
-option(LINQT_BUILD_INPUT_TOOLS "Fetch + build the external wannier2sparse for tests" ON)
+option(LSQUANT_BUILD_UTILITIES   "Build the Python helper utilities" OFF)
+option(LSQUANT_BUILD_INPUT_TOOLS "Fetch + build the external wannier2sparse for tests" ON)
 
 # --- Dependencies ------------------------------------------------------------
 # Eigen3: prefer a real config-package (Eigen3::Eigen); fall back to a header dir.
@@ -64,7 +64,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 # --- Targets -----------------------------------------------------------------
 add_subdirectory(src)
 
-if(LINQT_BUILD_UTILITIES)
+if(LSQUANT_BUILD_UTILITIES)
     add_subdirectory(utilities)
 endif()
 
@@ -72,7 +72,7 @@ endif()
 # vendored or distributed. It is fetched + built only on demand for tests.
 # (cmake/FetchWannier2Sparse.cmake wraps scripts/fetch_wannier2sparse.sh, pinned
 #  to a commit of github.com/adamecius/wannier2sparse.)
-if(LINQT_BUILD_INPUT_TOOLS)
+if(LSQUANT_BUILD_INPUT_TOOLS)
     include(cmake/FetchWannier2Sparse.cmake OPTIONAL)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ ctest --test-dir build        # optional: 24 checks, all should pass
 
 Build options:
 
-- `-DLINQT_BUILD_INPUT_TOOLS=ON|OFF` (default **ON**) — fetch and build the
+- `-DLSQUANT_BUILD_INPUT_TOOLS=ON|OFF` (default **ON**) — fetch and build the
   pinned `wannier2sparse` used to generate the test fixtures; it clones at
   configure time and degrades gracefully offline.
-- `-DLINQT_BUILD_UTILITIES=ON|OFF` (default **OFF**) — build the Python helper
+- `-DLSQUANT_BUILD_UTILITIES=ON|OFF` (default **OFF**) — build the Python helper
   utilities.
 
 ## The `lsquant` interface

--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,7 @@ so the row-parallel SpMV is bit-for-bit the serial result).
 - [ ] **Optional dependency accelerators.** The JSON reader and logger are
       in-house (offline-safe, hook-compliant). If desired, add
       `find_package(nlohmann_json)` / `find_package(spdlog)` as *optional*
-      accelerators behind the existing `LSQ_WITH_JSON` / `LINQT_WITH_SPDLOG`
+      accelerators behind the existing `LSQ_WITH_JSON` / `LSQUANT_WITH_SPDLOG`
       gates, keeping the in-house fallback (see `reporting_system.md` §5,
       `unified_io.md` §5).
 - [ ] **Plan-doc decision points.** Confirm the open D1–D5 / E1–E6 choices in

--- a/agent_template/documentation_STYLE_GUIDE.md
+++ b/agent_template/documentation_STYLE_GUIDE.md
@@ -1,4 +1,4 @@
-# How to document LinQT code
+# How to document LSQUANT code
 
 This guide explains how to turn `DOCSTRING_TEMPLATE.md` into finished in-code
 documentation, and it is opinionated about voice on purpose, in the same spirit

--- a/agent_template/documentation_TEMPLATE.md
+++ b/agent_template/documentation_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-  LinQT in-code documentation template.
+  LSQUANT in-code documentation template.
   Copy the skeleton for your language into your source file and fill the
   [[ ... ]] slots. The <!-- ... --> comments are guidance for the author; they
   never reach the reader, so delete them or leave them in this file.

--- a/agent_template/tutorial_style.md
+++ b/agent_template/tutorial_style.md
@@ -1,4 +1,4 @@
-# How to write a LinQT tutorial
+# How to write a LSQUANT tutorial
 
 This guide explains how to turn `TEMPLATE.md` into a finished tutorial, and it
 is opinionated about voice on purpose. Tutorial 1 (`examples/01_dos_1d_chain`)
@@ -108,7 +108,7 @@ Every tutorial ends with the same footer, nothing more by default:
 ```markdown
 ## References and links
 
-- LinQT source and documentation: https://github.com/adamecius/lsquant
+- LSQUANT source and documentation: https://github.com/adamecius/lsquant
 - Methodology: Z. Fan, J. H. García, A. W. Cummings et al., *Linear Scaling
   Quantum Transport Methodologies*, arXiv:1811.07387.
 - Installation: see the main README of the repository.

--- a/agent_template/tutorial_template.md
+++ b/agent_template/tutorial_template.md
@@ -1,5 +1,5 @@
 <!--
-  LinQT tutorial template.
+  LSQUANT tutorial template.
   Copy this file to examples/NN_short_name/README.md and fill the [[ ... ]] slots.
   The <!-- ... --> comments are guidance for the author. They are HTML comments,
   so they stay invisible when the page renders on GitHub. Delete them or leave
@@ -114,7 +114,7 @@ subtlety the reader would otherwise get wrong, name it plainly here.]]
 
 ## References and links
 
-- LinQT source and documentation: https://github.com/adamecius/lsquant
+- LSQUANT source and documentation: https://github.com/adamecius/lsquant
 - Methodology: Z. Fan, J. H. García, A. W. Cummings et al., *Linear Scaling
   Quantum Transport Methodologies*, arXiv:1811.07387.
 - Installation: see the main README of the repository.

--- a/cmake/FetchWannier2Sparse.cmake
+++ b/cmake/FetchWannier2Sparse.cmake
@@ -4,7 +4,7 @@ execute_process(
   RESULT_VARIABLE W2S_RC)
 if(W2S_RC EQUAL 0 AND EXISTS "${W2S_BIN}")
   message(STATUS "wannier2sparse: ${W2S_BIN}")
-  set(LINQT_W2S_BIN "${W2S_BIN}" CACHE INTERNAL "external wannier2sparse binary")
+  set(LSQUANT_W2S_BIN "${W2S_BIN}" CACHE INTERNAL "external wannier2sparse binary")
 else()
   message(WARNING "wannier2sparse unavailable (offline?). Goldens will not be (re)generated; "
                   "committed goldens remain usable.")

--- a/include/sparse_matrix.hpp
+++ b/include/sparse_matrix.hpp
@@ -1,6 +1,6 @@
 /**
  * @file sparse_matrix.hpp
- * @brief Sparse operator type used throughout LinQT.
+ * @brief Sparse operator type used throughout LSQUANT.
  *
  * Defines @ref SparseMatrixType, the matrix-free complex sparse operator (CSR, Eigen
  * RowMajor backend) on which all KPM recursions act, and @ref SparseMatrixBuilder, which

--- a/include/util/log.hpp
+++ b/include/util/log.hpp
@@ -6,7 +6,7 @@
 // A thin, levelled, thread-safe logger. Call sites use the LSQ_LOG_* macros and
 // never include a backend header, so the implementation (currently an in-house,
 // zero-dependency, offline-safe sink set) can be swapped for spdlog later behind
-// LINQT_WITH_SPDLOG without touching a single call site.
+// LSQUANT_WITH_SPDLOG without touching a single call site.
 //
 //   LSQ_LOG_INFO("saved " << n << " moments to " << name);
 //   LSQ_LOG_WARN("non-Hermitian input, symmetrising");

--- a/infrastructure_plan.md
+++ b/infrastructure_plan.md
@@ -84,14 +84,14 @@ pinned `FetchContent` (offline-graceful, like `cmake/FetchWannier2Sparse.cmake`)
 
 | Need | Pick | Mode | CMake gate |
 |---|---|---|---|
-| Logging | **spdlog** (`libspdlog-dev`) | find → fetch → in-house fallback | `LINQT_WITH_SPDLOG` (ON) |
+| Logging | **spdlog** (`libspdlog-dev`) | find → fetch → in-house fallback | `LSQUANT_WITH_SPDLOG` (ON) |
 | Error vocab | **tl::expected** (C++11 backport of `std::expected`) | vendored header | — |
 | JSON parse/emit | **nlohmann/json** (`nlohmann-json3-dev`) | find → fetch → vendored header | `LSQ_WITH_JSON` |
-| Schema validation | **pboettch/json-schema-validator** | find → fetch → semantic-only fallback | `LINQT_WITH_JSON_SCHEMA` (ON) |
+| Schema validation | **pboettch/json-schema-validator** | find → fetch → semantic-only fallback | `LSQUANT_WITH_JSON_SCHEMA` (ON) |
 | Fingerprint hash | **picosha2** (SHA-256) | vendored header | — |
-| Deep profiling (later) | **Tracy** | opt-in | `LINQT_WITH_TRACY` (OFF) |
-| HW counters (later) | **PAPI** / `perf_event_open` | opt-in | `LINQT_WITH_PAPI` (OFF) |
-| Plots/HTML (Python) | **Plotly** + numpy | `requirements.txt` | `LINQT_BUILD_UTILITIES` |
+| Deep profiling (later) | **Tracy** | opt-in | `LSQUANT_WITH_TRACY` (OFF) |
+| HW counters (later) | **PAPI** / `perf_event_open` | opt-in | `LSQUANT_WITH_PAPI` (OFF) |
+| Plots/HTML (Python) | **Plotly** + numpy | `requirements.txt` | `LSQUANT_BUILD_UTILITIES` |
 
 In-house (no good tiny cross-platform dep exists): the resource probe interface +
 Linux backend, the scoped timers, and the domain-specific **physics merge**

--- a/reporting_system.md
+++ b/reporting_system.md
@@ -133,7 +133,7 @@ levels (`trace…critical`), multiple sinks (stdout-color, basic/rotating file),
   `include/util/log.hpp`) — `LSQ_LOG_INFO(...)`, `_WARN`, `_ERROR`, `_DEBUG`,
   `_TRACE`. Internals call spdlog. This means call sites never include
   `<spdlog/...>` directly, so spdlog can be swapped or compiled out behind a
-  macro (`LINQT_WITH_SPDLOG`) without touching numerics.
+  macro (`LSQUANT_WITH_SPDLOG`) without touching numerics.
 - **Default sinks:** colored stderr (human) at `info`; optional rotating file
   `lsquant.log` when `--log-file` / `LSQUANT_LOG_FILE` is set. Level controlled by
   `LSQUANT_LOG_LEVEL` env + a `--verbose/-v` CLI flag wired in `lsquant.cpp`.
@@ -172,7 +172,7 @@ Modernize and unify into `include/util/timer.hpp`:
   current users keep compiling. Migrate call sites opportunistically, not in a
   big bang — keeps this change additive and auditable.
 
-Optional deep-profiling backend (future, behind `LINQT_WITH_TRACY`): **Tracy**
+Optional deep-profiling backend (future, behind `LSQUANT_WITH_TRACY`): **Tracy**
 frame profiler for flame-graph analysis of the hot loops. Out of scope for v1;
 the `Timer` API is designed so a Tracy zone can be emitted alongside.
 
@@ -253,7 +253,7 @@ ResourceSnapshot sample();             // convenience
   (`mach/task.h`), Windows `GetProcessMemoryInfo` (PSAPI). HPC extensions —
   **PAPI** or Linux `perf_event_open` for hardware counters, jemalloc/tcmalloc
   `mallctl` stats for allocator-level detail — slot in as additional `ResourceProbe`
-  implementations behind `LINQT_WITH_PAPI` etc.
+  implementations behind `LSQUANT_WITH_PAPI` etc.
 - **Usage pattern:** a `ScopedResourceReport` RAII (sibling of `ScopedTimer`)
   logs `ΔRSS` and CPU at the end of a major phase (moment computation,
   reconstruction). The `lsquant` driver prints a final one-line summary:
@@ -271,10 +271,10 @@ ResourceSnapshot sample();             // convenience
 Follow the existing imported-target + pinned-fetch + graceful-offline pattern.
 
 - New options (default the heavy/optional bits **OFF** or auto):
-  - `LINQT_WITH_SPDLOG` (default **ON**, auto-off if neither system pkg nor fetch
+  - `LSQUANT_WITH_SPDLOG` (default **ON**, auto-off if neither system pkg nor fetch
     available → falls back to in-house logger).
-  - `LINQT_WITH_TRACY` (default **OFF**).
-  - `LINQT_WITH_PAPI` (default **OFF**).
+  - `LSQUANT_WITH_TRACY` (default **OFF**).
+  - `LSQUANT_WITH_PAPI` (default **OFF**).
 - **spdlog resolution order**, mirroring Eigen's fallback ladder
   (`CMakeLists.txt:32-46`):
   1. `find_package(spdlog QUIET)` → `spdlog::spdlog` (Ubuntu `libspdlog-dev`).

--- a/scripts/regenerate_goldens.sh
+++ b/scripts/regenerate_goldens.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Regenerate LinQT golden masters, deterministically.
+# Regenerate LSQUANT golden masters, deterministically.
 #
 # Pipeline (mirrors the reference flow, corrected to the real tool/driver CLIs):
 #   external wannier2sparse  ->  inline_compute-kpm-nonEqOp  ->  inline_kuboBastinFromChebmom
@@ -21,7 +21,7 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO"
 
 W2S="$(bash scripts/fetch_wannier2sparse.sh)"   # cache-aware; offline-safe on cache hit
-BUILD="$(cd "${1:-build}" && pwd)"              # absolute path to the LinQT build dir
+BUILD="$(cd "${1:-build}" && pwd)"              # absolute path to the LSQUANT build dir
 
 SEED=graphene_golden
 OUT="$REPO/test/golden"
@@ -54,7 +54,7 @@ COUT="$OUT/chain1d"
   printf -- "-2 2\n" > BOUNDS                       # EXACT band
   # EXACT TRACE: a local-state set over the full basis e_0..e_{D-1} makes
   # SpectralMoments compute Sum_i <e_i|T_m|e_i>/D = Tr[T_m]/D exactly (no random
-  # vector, deterministic, machine precision). Uses LinQT's own kernel; no source change.
+  # vector, deterministic, machine precision). Uses LSQUANT's own kernel; no source change.
   DIM=$(head -1 operators/chain1d.HAM.CSR | awk '{print $1}')
   { echo local; echo "$DIM"; seq 0 $((DIM-1)); } > exact
   "$BUILD/inline_compute-kpm-nonEqOp"  chain1d VX VX "$M" exact   # #3 KG moments (exact) -> .chebmom2D

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(kpm_lib PUBLIC
 # *FromChebmom drivers are still built individually here; collapsing them into a
 # single parametrised driver is a separate source-level refactor (Plan 2), not a
 # build-file change.
-set(LINQT_APPS
+set(LSQUANT_APPS
     "inline_compute-kpm-nonEqOp|inline_compute-kpm-nonEqOp.cpp"
     "inline_compute-kpm-CorrOp|inline_compute-kpm-CorrOp.cpp"
     "inline_compute-kpm-spectralOp|inline_compute-kpm-spectralOp.cpp"
@@ -108,7 +108,7 @@ set(LINQT_APPS
     "lsquant|lsquant.cpp"
 )
 
-foreach(entry IN LISTS LINQT_APPS)
+foreach(entry IN LISTS LSQUANT_APPS)
     string(REPLACE "|" ";" parts "${entry}")
     list(GET parts 0 app_name)
     list(GET parts 1 app_src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Golden-master harness for LinQT.
+# Golden-master harness for LSQUANT.
 #
 # Goldens (committed under test/golden/) are produced by the reference pipeline
 # external wannier2sparse -> inline_compute-kpm-nonEqOp -> inline_kuboBastinFromChebmom,
@@ -18,10 +18,10 @@ add_dependencies(regenerate-goldens
     inline_compute-kpm-nonEqOp inline_kuboBastinFromChebmom)
 
 # First-build bootstrap: generate goldens as part of ALL when they are absent
-# (or forced via -DLINQT_REGEN_GOLDENS=ON) AND the external input tool is enabled.
+# (or forced via -DLSQUANT_REGEN_GOLDENS=ON) AND the external input tool is enabled.
 # The EXISTS check is evaluated at configure time, so committed goldens make this
 # a no-op on subsequent configures (idempotent).
-if(LINQT_BUILD_INPUT_TOOLS AND (LINQT_REGEN_GOLDENS OR NOT EXISTS ${GOLDEN_STAMP}))
+if(LSQUANT_BUILD_INPUT_TOOLS AND (LSQUANT_REGEN_GOLDENS OR NOT EXISTS ${GOLDEN_STAMP}))
     add_custom_target(bootstrap-goldens ALL
         COMMAND bash ${REGEN_SCRIPT} ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -115,7 +115,7 @@ add_test(NAME msd_ballistic
 # The Haldane Chern insulator (t1=-1,t2=0.15,phi=pi/2; 16x16) has a quantized Hall
 # plateau in the gap: sigma_xy = C*e^2/h with C=+1. Regenerates VX-VY moments by exact
 # trace from the committed operators, reconstructs Kubo-Bastin (NaN-free via alpha), and
-# asserts (plateau/A)*2pi = +1 within finite-size tolerance. This is LinQT's quantized
+# asserts (plateau/A)*2pi = +1 within finite-size tolerance. This is LSQUANT's quantized
 # "conductance quantum" test. Reference = the topological invariant (oracle), not a run.
 set(HALL_M 128)         # 8s exact-trace; C=+1.017 at this M (1.7% finite-M error)
 set(HALL_TOL 0.05)
@@ -126,7 +126,7 @@ add_test(NAME hall_haldane
 # A +x-polarised spin in the Zeeman field H_hop - J_ex*sigma_z precesses:
 # <S(t)> = cos(wt)x - sin(wt)y, S_z=0, w = 2*J_ex/hbar (physical hbar=0.6582 eV*fs;
 # period 20.68 fs), E_F-independent. Density projection path, exact trace -> machine
-# precision. Validates LinQT's time-evolution + spin-projection machinery end-to-end.
+# precision. Validates LSQUANT's time-evolution + spin-projection machinery end-to-end.
 set(PREC_M 32)
 add_test(NAME spin_precession
          COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/spin_precession.sh ${CMAKE_BINARY_DIR} ${PREC_M})

--- a/test/chain1d_analytic_test.cpp
+++ b/test/chain1d_analytic_test.cpp
@@ -1,4 +1,4 @@
-// Analytic golden test (#3): LinQT Kubo-Greenwood Chebyshev moment matrix for the
+// Analytic golden test (#3): LSQUANT Kubo-Greenwood Chebyshev moment matrix for the
 // monoatomic 1D chain vs the closed form (thesis Eq. 4.9, B.15 normalized).
 //
 // Usage: chain1d_analytic_test <chebmom2D file> <TOL>

--- a/test/chain1d_reproduce.sh
+++ b/test/chain1d_reproduce.sh
@@ -4,7 +4,7 @@
 #
 # The goldens are now computed by EXACT TRACE: a local-state set over the full basis
 # e_0..e_{D-1} makes SpectralMoments evaluate Sum_i <e_i|T_m|e_i>/D = Tr[T_m]/D exactly,
-# through LinQT's own Chebyshev kernel, with no random vector. So:
+# through LSQUANT's own Chebyshev kernel, with no random vector. So:
 #   (1) two runs are byte-identical (deterministic by construction), and
 #   (2) the fresh moments satisfy the analytic reference at MACHINE precision (TOL ~ 1e-9),
 #       checked by the C++ comparators (no Python). No byte-diff against the committed

--- a/test/hall_haldane.sh
+++ b/test/hall_haldane.sh
@@ -3,7 +3,7 @@
 #
 # The Haldane model (t1=-1, t2=0.15, phi=pi/2) is a Chern insulator: with the Fermi level
 # in the gap the Hall conductivity is quantized at sigma_xy = C*e^2/h with Chern C = +1.
-# This is LinQT's finite, quantized "conductance quantum" test and the end-to-end exercise
+# This is LSQUANT's finite, quantized "conductance quantum" test and the end-to-end exercise
 # of the Kubo-Bastin route (which is NaN-free only with the alpha safeguard, see
 # docs/spectral_scales.md).
 #

--- a/test/spin_precession.sh
+++ b/test/spin_precession.sh
@@ -3,7 +3,7 @@
 #
 # The magnetic chain is a constant Zeeman field H = H_hop - J_ex*sigma_z (J_ex=0.1). A spin
 # prepared along +x precesses in the x-y plane at the Larmor frequency set by the Zeeman
-# splitting 2*J_ex. In LinQT's PHYSICAL units (hbar = 0.6582119624 eV*fs, time in fs):
+# splitting 2*J_ex. In LSQUANT's PHYSICAL units (hbar = 0.6582119624 eV*fs, time in fs):
 #
 #     <S_x(t)> =  cos(omega t),  <S_y(t)> = -sin(omega t),  <S_z(t)> = 0,
 #     omega = 2*J_ex/hbar = 0.2/0.6582119624 = 0.30385 rad/fs   (period 20.68 fs),

--- a/unified_io.md
+++ b/unified_io.md
@@ -273,13 +273,13 @@ vendored header — so the project stays offline-safe.
 
 - `nlohmann/json`: `find_package(nlohmann_json)` (Ubuntu `nlohmann-json3-dev`) →
   fetch → vendored single header. Define `LSQ_WITH_JSON`.
-- `json-schema-validator`: find → fetch → vendor; gated `LINQT_WITH_JSON_SCHEMA`
+- `json-schema-validator`: find → fetch → vendor; gated `LSQUANT_WITH_JSON_SCHEMA`
   (default ON; if absent, fall back to the semantic-only validator in 4.2).
 - `picosha2`: vendored single header (no option needed).
 - New sources under `src/io/` (`config.cpp`, `validate.cpp`, `fingerprint.cpp`,
   `results.cpp`, `merge.cpp`) folded into `KPM_LIB_SOURCES` so every driver gets
   them; new public headers under `include/io/`.
-- Python presenter: optional `LINQT_BUILD_UTILITIES` already exists — hook
+- Python presenter: optional `LSQUANT_BUILD_UTILITIES` already exists — hook
   `lsquant_report.py` there; add a `requirements.txt` (numpy, plotly).
 
 ## 6. Rollout (additive, auditable)

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Helper utilities. The vendored wannier2sparse and wannier2sparse2 generators
 # have been removed: input generation now uses the standalone, externally-built
-# github.com/adamecius/wannier2sparse (see LINQT_BUILD_INPUT_TOOLS). siesta2sparse
+# github.com/adamecius/wannier2sparse (see LSQUANT_BUILD_INPUT_TOOLS). siesta2sparse
 # is pure Python and self-contained.
 add_subdirectory(python)


### PR DESCRIPTION
Stacked on #62. Completes the rename beyond user-facing docs: code comments, agent_template docs, and the CMake identifiers `LINQT_BUILD_*`/`LINQT_REGEN_GOLDENS`/`LINQT_W2S_BIN`/`LINQT_APPS`/`LINQT_WITH_*` -> `LSQUANT_*` (defs + all uses + README/planning-doc references).

**Verified:** reconfigure + build clean, fast gate 5/5 green (bit-exact gates + goldens + single_binary); option defaults unchanged, only names. No numerics/goldens touched.

**Heads-up:** users passing `-DLINQT_BUILD_INPUT_TOOLS`/`-DLINQT_BUILD_UTILITIES` must switch to `-DLSQUANT_BUILD_*`. `docs/references.md` (maintainer's uncommitted file) left untouched.