### PR TITLE
docs: restore Read the Docs as a secondary mirror (GitHub Pages stays main)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,13 @@
-# GitHub Pages build for the LSQUANT Doxygen site — the sole host.
+# GitHub Pages build for the LSQUANT Doxygen site — the MAIN host.
 #
-# Read the Docs has been retired: its build container has no root, so the
-# apt_packages it needs (cmake, doxygen, Eigen, ...) were silently dropped the
-# moment .readthedocs.yaml used build.commands, and the configure step died with
-# no toolchain. GitHub Actions runners have root and ship cmake/g++/pkg-config,
-# so `apt-get install doxygen graphviz` works — the right host for a
-# CMake/Doxygen artifact. The CMake flags below are unchanged from the docs
-# target, so only the host moves; the target itself is untouched.
+# Two hosts build the same site independently: GitHub Pages here (main), and
+# Read the Docs (.readthedocs.yaml) as a secondary mirror. GitHub Actions runners
+# have root and ship cmake/g++/pkg-config, so `apt-get install ...` works; this is
+# the natural home for a CMake/Doxygen artifact. The CMake flags below match the
+# `docs` target exactly, so only the host wiring lives here; the target itself is
+# untouched. (RTD installs its apt_packages with root too, so it builds the same
+# way; the earlier RTD failure was only that .readthedocs.yaml had not yet reached
+# the default branch.)
 #
 # Pitfall: the configure step still needs the Eigen/GSL/FFTW -dev packages
 # because the top-level CMakeLists find_package()s them, even though the docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,48 @@
+# Read the Docs build for the LSQUANT Doxygen site — SECONDARY mirror.
+#
+# GitHub Pages (.github/workflows/docs.yml) is the main host; this file keeps a
+# second, independent copy of the same site building on readthedocs.org.
+#
+# RTD natively expects a Sphinx project, so we take full control with
+# `build.commands`: configure with -DBUILD_DOCS=ON, build the `docs` target
+# (Doxygen only, no source compiled), then copy the HTML into the directory RTD
+# serves.
+#
+# Why the earlier RTD build failed (and why this works): the failure was simply
+# that .readthedocs.yaml was not yet on the branch RTD builds (the default
+# branch / `latest`), so RTD reported "config file not found". It was NOT an apt
+# problem: `build.apt_packages` is installed by Read the Docs itself with root
+# privileges, before `build.commands` run, and applies even when build.commands
+# is used. The packages below therefore are available to the configure step.
+#
+# Pitfall: the configure step needs the Eigen/GSL/FFTW -dev packages because the
+# top-level CMakeLists find_package()s them, even though the docs target compiles
+# no source.
+#
+# Warning: the served site must land under "$READTHEDOCS_OUTPUT/html" or RTD
+# publishes nothing. The CMake docs target writes build/docs/html; we copy it.
+#
+# To-do: when the planned Sphinx + Breathe + MyST layer lands (it consumes the
+# Doxygen XML this build already emits), switch to the native `sphinx:` key and
+# drop the manual copy.
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    # Required to define the build environment; also ready for the future Sphinx layer.
+    python: "3.12"
+  apt_packages:
+    - cmake
+    - g++
+    - pkg-config
+    - doxygen
+    - graphviz
+    - libeigen3-dev
+    - libgsl-dev
+    - libfftw3-dev
+  commands:
+    - cmake -S . -B build -DBUILD_DOCS=ON -DLSQUANT_BUILD_INPUT_TOOLS=OFF -DBUILD_TESTING=OFF
+    - cmake --build build --target docs
+    - mkdir -p "$READTHEDOCS_OUTPUT/html"
+    - cp -a build/docs/html/. "$READTHEDOCS_OUTPUT/html/"


### PR DESCRIPTION
Brings `.readthedocs.yaml` back so the site builds on **both** hosts: **GitHub Pages (main)** and **Read the Docs (secondary mirror)**.

## Why it was missing
PR #67 removed `.readthedocs.yaml` and called Pages the "sole host", on the premise that RTD drops `apt_packages` because its build container has no root. **That premise is wrong:** Read the Docs installs `build.apt_packages` *itself, with root*, before `build.commands` run, and they apply even when `build.commands` is used. The RTD build you saw failed for one reason only — `.readthedocs.yaml` was not on the branch RTD builds (`latest` = default branch), so RTD reported *"config file not found"*.

## What changes
- **`.readthedocs.yaml`** (restored) — Doxygen-only RTD build via `build.commands` + `build.apt_packages`, copying `build/docs/html` into `$READTHEDOCS_OUTPUT/html`. Framed as the secondary mirror.
- **`.github/workflows/docs.yml`** — **comment header only**: dual hosting (Pages main, RTD secondary) instead of "sole host / retired". The functional steps (ubuntu-24.04, apt install, CMake flags, artifact + deploy) are unchanged.

## Independent of the two one-time account toggles
- **GitHub Pages:** the build job already passes; only the deploy step is blocked on **Settings → Pages → Source = GitHub Actions** (not affected by this PR).
- **Read the Docs:** once this lands on the default branch, RTD finds the config and builds (trigger *Build version* / it auto-builds via webhook).

## Safety
No source/test/CMake-logic change; `BUILD_DOCS` stays OFF by default. See PR #65 for the full §4 record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)