### PR TITLE
docs(rtd): use build.jobs so apt_packages install (fixes the RTD build)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,28 +3,23 @@
 # GitHub Pages (.github/workflows/docs.yml) is the main host; this file keeps a
 # second, independent copy of the same site building on readthedocs.org.
 #
-# RTD natively expects a Sphinx project, so we take full control with
-# `build.commands`: configure with -DBUILD_DOCS=ON, build the `docs` target
-# (Doxygen only, no source compiled), then copy the HTML into the directory RTD
-# serves.
-#
-# Why the earlier RTD build failed (and why this works): the failure was simply
-# that .readthedocs.yaml was not yet on the branch RTD builds (the default
-# branch / `latest`), so RTD reported "config file not found". It was NOT an apt
-# problem: `build.apt_packages` is installed by Read the Docs itself with root
-# privileges, before `build.commands` run, and applies even when build.commands
-# is used. The packages below therefore are available to the configure step.
+# Why build.jobs and not build.commands: Read the Docs only installs
+# `build.apt_packages` when the build uses `build.jobs` (or the default Sphinx
+# flow). With `build.commands` the apt step is silently skipped, so cmake,
+# doxygen and the -dev libraries were never installed and the configure step had
+# no toolchain. `build.jobs.build.html` keeps apt_packages working (Read the Docs
+# installs them with root, before the job runs) while still letting us drive the
+# CMake `docs` target ourselves and emit HTML where RTD serves it.
 #
 # Pitfall: the configure step needs the Eigen/GSL/FFTW -dev packages because the
 # top-level CMakeLists find_package()s them, even though the docs target compiles
 # no source.
 #
-# Warning: the served site must land under "$READTHEDOCS_OUTPUT/html" or RTD
-# publishes nothing. The CMake docs target writes build/docs/html; we copy it.
+# Warning: HTML must be written under "$READTHEDOCS_OUTPUT/html" or RTD publishes
+# nothing. The CMake docs target writes build/docs/html; the last job copies it.
 #
 # To-do: when the planned Sphinx + Breathe + MyST layer lands (it consumes the
-# Doxygen XML this build already emits), switch to the native `sphinx:` key and
-# drop the manual copy.
+# Doxygen XML this build already emits), switch to the native `sphinx:` key.
 version: 2
 
 build:
@@ -41,8 +36,10 @@ build:
     - libeigen3-dev
     - libgsl-dev
     - libfftw3-dev
-  commands:
-    - cmake -S . -B build -DBUILD_DOCS=ON -DLSQUANT_BUILD_INPUT_TOOLS=OFF -DBUILD_TESTING=OFF
-    - cmake --build build --target docs
-    - mkdir -p "$READTHEDOCS_OUTPUT/html"
-    - cp -a build/docs/html/. "$READTHEDOCS_OUTPUT/html/"
+  jobs:
+    build:
+      html:
+        - cmake -S . -B build -DBUILD_DOCS=ON -DLSQUANT_BUILD_INPUT_TOOLS=OFF -DBUILD_TESTING=OFF
+        - cmake --build build --target docs
+        - mkdir -p "$READTHEDOCS_OUTPUT/html"
+        - cp -a build/docs/html/. "$READTHEDOCS_OUTPUT/html/"


### PR DESCRIPTION
Fixes the Read the Docs build that stalled at `cmake` with no toolchain.

## Root cause (verified against RTD docs)
Read the Docs **only installs `build.apt_packages` with `build.jobs`** (or the default Sphinx flow) — **not with `build.commands`**. Our config used `build.commands`, so RTD skipped the apt install entirely. Your build log proves it: it went `asdf global python` → `cmake …` with **no `apt-get` step**, so `cmake`/`doxygen`/Eigen/GSL/FFTW were never installed.

> RTD docs: *"build.jobs offers the same functionality as build.commands … while also supporting installing system dependencies via build.apt_packages."*

## Fix
Switch `.readthedocs.yaml` from `build.commands` to **`build.jobs.build.html`**:
- `apt_packages` (cmake, g++, pkg-config, doxygen, graphviz, libeigen3/gsl/fftw-dev) now install — RTD runs apt with root *before* the job.
- The same CMake `docs` target runs; HTML is copied to `$READTHEDOCS_OUTPUT/html`.

## Hosts after this lands
- **GitHub Pages (main):** unaffected — its build job already passes; still needs the one-time **Settings → Pages → Source = GitHub Actions** toggle to publish.
- **Read the Docs (secondary):** rebuilds on push / *Build version*; the toolchain is now present.

## Safety
No source/test/CMake-logic change; `BUILD_DOCS` stays OFF by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)